### PR TITLE
Bash completion with argcomplete

### DIFF
--- a/httpie-completion.bash
+++ b/httpie-completion.bash
@@ -1,22 +1,3 @@
 #!/bin/env bash
 
-_http_complete() {
-	local cur_word=${COMP_WORDS[COMP_CWORD]}
-	local prev_word=${COMP_WORDS[COMP_CWORD - 1]}
-
-	if [[ "$cur_word" == -*  ]]; then
-		_http_complete_options "$cur_word"
-	fi
-}
-
-complete -o default -F _http_complete http
-
-_http_complete_options() {
-	local cur_word=$1
-	local options="-j --json -f --form --pretty -s --style -p --print 
-	-v --verbose -h --headers -b --body -S --stream -o --output -d --download
-	-c --continue --session --session-read-only -a --auth --auth-type --proxy
-	--follow --verify --cert --cert-key --timeout --check-status --ignore-stdin
-	--help --version --traceback --debug"
-	COMPREPLY=( $( compgen -W "$options" -- "$cur_word" ) )
-}
+eval "$(register-python-argcomplete http)"

--- a/httpie/cli.py
+++ b/httpie/cli.py
@@ -21,7 +21,6 @@ from httpie.input import (Parser, AuthCredentialsArgType, KeyValueArgType,
                           PRETTY_STDOUT_TTY_ONLY, SessionNameValidator,
                           readable_file_arg)
 
-
 class HTTPieHelpFormatter(RawDescriptionHelpFormatter):
     """A nicer help formatter.
 
@@ -72,6 +71,7 @@ positional.add_argument(
     metavar='METHOD',
     nargs=OPTIONAL,
     default=None,
+    choices=('GET', 'PUT', 'POST', 'HEAD', 'CONNECT'),
     help="""
     The HTTP method to be used for the request (GET, POST, PUT, DELETE, ...).
 

--- a/httpie/core.py
+++ b/httpie/core.py
@@ -27,7 +27,7 @@ from httpie.output.streams import (
     build_output_stream,
     write, write_with_colors_win_py3
 )
-
+import argcomplete
 
 def get_exit_status(http_status, follow=False):
     """Translate HTTP status code to exit status code."""
@@ -98,6 +98,7 @@ def main(args=sys.argv[1:], env=Environment()):
     download = None
 
     try:
+        argcomplete.autocomplete(parser)
         args = parser.parse_args(args=args, env=env)
 
         if args.download:

--- a/httpie/core.py
+++ b/httpie/core.py
@@ -27,7 +27,12 @@ from httpie.output.streams import (
     build_output_stream,
     write, write_with_colors_win_py3
 )
-import argcomplete
+HAS_ARGCOMPLETE=False
+try:
+    import argcomplete
+    HAS_ARGCOMPLETE=True
+except ImportError:
+    pass
 
 def get_exit_status(http_status, follow=False):
     """Translate HTTP status code to exit status code."""
@@ -98,7 +103,8 @@ def main(args=sys.argv[1:], env=Environment()):
     download = None
 
     try:
-        argcomplete.autocomplete(parser)
+        if HAS_ARGCOMPLETE:
+            argcomplete.autocomplete(parser)
         args = parser.parse_args(args=args, env=env)
 
         if args.download:

--- a/setup.py
+++ b/setup.py
@@ -49,11 +49,6 @@ if not 'bdist_wheel' in sys.argv:
     except ImportError:
         install_requires.append('argparse>=1.2.1')
 
-    try:
-        import argcomplete
-    except ImportError:
-        install_requires.append('argcomplete>=0.8.4')
-
     if 'win32' in str(sys.platform).lower():
         # Terminal colors for Windows
         install_requires.append('colorama>=0.2.4')

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ extras_require = {
     # http://wheel.readthedocs.org/en/latest/#defining-conditional-dependencies
     ':python_version == "2.6"'
     ' or python_version == "3.0"'
-    ' or python_version == "3.1" ': ['argparse>=1.2.1'],
+    ' or python_version == "3.1" ': ['argparse>=1.2.1','argcomplete>=0.8.4'],
     ':sys_platform == "win32"': ['colorama>=0.2.4'],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,11 @@ if not 'bdist_wheel' in sys.argv:
     except ImportError:
         install_requires.append('argparse>=1.2.1')
 
+    try:
+        import argcomplete
+    except ImportError:
+        install_requires.append('argcomplete')
+
     if 'win32' in str(sys.platform).lower():
         # Terminal colors for Windows
         install_requires.append('colorama>=0.2.4')

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ if not 'bdist_wheel' in sys.argv:
     try:
         import argcomplete
     except ImportError:
-        install_requires.append('argcomplete')
+        install_requires.append('argcomplete>=0.8.4')
 
     if 'win32' in str(sys.platform).lower():
         # Terminal colors for Windows


### PR DESCRIPTION
See #331 #332 
So, here is what argcomplete looks like. It is relatively easy but it
requires an additional "argcomplete" package available on pip.

Also, have you thought of adding an -m and --method option for HTTP
methods? Any specific reason it was not a part of option and just a
sub command like syntax?
