### PR TITLE
Added support for XSSI Vulnerability Protected JSON

### DIFF
--- a/httpie/cli.py
+++ b/httpie/cli.py
@@ -223,6 +223,17 @@ output_processing.add_argument(
         ).rstrip(),
     )
 )
+output_processing.add_argument(
+    '--xssi', '-x',
+    dest='xssi_prefix',
+    metavar='PREFIX',
+    default='',
+    help="""
+    (default) Assumes incoming JSON has no XSSI Prefix
+    Allows Specifying a particular XSSI Prefix for the incoming JSON.
+
+    """
+)
 
 
 #######################################################################

--- a/httpie/output/formatters/json.py
+++ b/httpie/output/formatters/json.py
@@ -17,6 +17,9 @@ class JSONFormatter(FormatterPlugin):
         ]
         if (self.kwargs['explicit_json'] or
                 any(token in mime for token in maybe_json)):
+            xssi_prefix = self.kwargs["xssi_prefix"]
+            if xssi_prefix and body.startswith(xssi_prefix):
+                body = body[len(xssi_prefix):]
             try:
                 obj = json.loads(body)
             except ValueError:

--- a/httpie/output/streams.py
+++ b/httpie/output/streams.py
@@ -117,6 +117,7 @@ def get_stream_type(env, args):
                 groups=args.prettify,
                 color_scheme=args.style,
                 explicit_json=args.json,
+                xssi_prefix=args.xssi_prefix
             ),
         )
     else:


### PR DESCRIPTION
XSSI Vulnerability protection usually involves prefixing all JSON
data with a particular prefix to make it non-executable.
HTTPie does not display the resulting JSON in pretty print format.
My changes add support for specifying a prefix so that HTTPie can strip
it before parsing the data as JSON.
