### PR TITLE
Add the packaging metadata to build the httpie snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: httpie
+name: http
 version: master
 summary: Modern command line HTTP client
 description: |
@@ -15,7 +15,6 @@ apps:
   http:
     command: http
     plugs: [network, home]
-    aliases: [http]
 
 parts:
   httpie:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: httpie
+version: master
+summary: Modern command line HTTP client
+description: |
+  HTTPie (pronounced aitch-tee-tee-pie) is a command line HTTP client. Its goal
+  is to make CLI interaction with web services as human-friendly as possible.
+  It provides a simple http command that allows for sending arbitrary HTTP
+  requests using a simple and natural syntax, and displays colorized output.
+  HTTPie can be used for testing, debugging, and generally interacting with HTTP servers.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict
+
+apps:
+  http:
+    command: http
+    plugs: [network, home]
+    aliases: [http]
+
+parts:
+  httpie:
+    source: .
+    plugin: python


### PR DESCRIPTION
This is a package for the secure installation of apps that works in most Linux distributions.
Landing it upstream will enable builds that then can be continuously delivered to many users through the Ubuntu store.