### PR TITLE
Use 'UTF-8' as default encoding

### DIFF
--- a/httpie/models.py
+++ b/httpie/models.py
@@ -80,7 +80,9 @@ class HTTPResponse(HTTPMessage):
 
     @property
     def encoding(self):
-        return self._orig.encoding or 'utf8'
+        # requests use 'ISO-8859-1' as fallback, but we choose 'UTF-8'.
+        # see discussion in https://github.com/requests/requests/issues/2086
+        return self._orig.encoding if 'charset=' in self.content_type else 'utf8'
 
     @property
     def body(self):


### PR DESCRIPTION
Requests never return `None` when charset is missing in content type. So the code at L83 wouldn't work as expected.

You can use this command to test it: `http https://www.google.com/intl/zh-CN/policies/`.
It should output Chinese at end after apply this patch:
![image](https://user-images.githubusercontent.com/760097/28052725-3a6a7318-663f-11e7-889c-8a991a6a70a5.png)