### PR TITLE
Add 'random' color styles option

### DIFF
--- a/demo_config.json
+++ b/demo_config.json
@@ -1,0 +1,10 @@
+{
+    "__meta__": {
+        "about": "HTTPie configuration file",
+        "help": "https://github.com/jkbrzt/httpie#config",
+        "httpie": "0.9.6"
+    },
+    "default_options": [
+        "--style=random"
+    ]
+}

--- a/httpie/output/formatters/colors.py
+++ b/httpie/output/formatters/colors.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import json
+import random
 
 import pygments.lexer
 import pygments.token
@@ -18,6 +19,7 @@ from httpie.plugins import FormatterPlugin
 
 AVAILABLE_STYLES = set(pygments.styles.STYLE_MAP.keys())
 AVAILABLE_STYLES.add('solarized')
+AVAILABLE_STYLES.add('random')
 
 # This is the native style provided by the terminal emulator color scheme
 PRESET_STYLE = 'preset'
@@ -50,6 +52,9 @@ class ColorFormatter(FormatterPlugin):
 
         # --json, -j
         self.explicit_json = explicit_json
+
+        if color_scheme == 'random':
+            color_scheme = random.choice(list(pygments.styles.STYLE_MAP.keys()))
 
         try:
             style_class = pygments.styles.get_style_by_name(color_scheme)

--- a/httpie/output/formatters/colors.py
+++ b/httpie/output/formatters/colors.py
@@ -24,6 +24,16 @@ AVAILABLE_STYLES.add('random')
 # This is the native style provided by the terminal emulator color scheme
 PRESET_STYLE = 'preset'
 AVAILABLE_STYLES.add(PRESET_STYLE)
+STYLES_KEYS_EXCLUDED = [
+    'murphy',
+    'borland',
+    'colorful',
+    'manni',
+    'xcode',
+    'trac',
+    'friendly',
+    'tango'
+]
 
 if is_windows:
     # Colors on Windows via colorama don't look that
@@ -54,8 +64,12 @@ class ColorFormatter(FormatterPlugin):
         self.explicit_json = explicit_json
 
         if color_scheme == 'random':
-            color_scheme = random.choice(list(pygments.styles.STYLE_MAP.keys()))
-
+            # color_scheme = random.choice(['native', 'vim', 'paraiso-dark'])
+            color_scheme = random.choice(list(filter(
+                lambda a: a not in STYLES_KEYS_EXCLUDED,
+                list(pygments.styles.STYLE_MAP.keys())
+            )))
+            print("Style: %s\n---" % color_scheme)
         try:
             style_class = pygments.styles.get_style_by_name(color_scheme)
         except ClassNotFound:


### PR DESCRIPTION
I find it easier to distinguish between different calls in the terminal when the output is colored differently for each call, so you can more easily tell when one ends and the other begins. So I added `random` as an option!
Locally I rotate between only 3 of the colors since I don't like all of them but didn't want to make that choice for all.