### PR TITLE
#99 - add --resolve option

### DIFF
--- a/httpie/cli.py
+++ b/httpie/cli.py
@@ -533,7 +533,20 @@ network.add_argument(
 
     """
 )
-
+network.add_argument(
+    '--resolve',
+    default=[],
+    action='append',
+    metavar='HOST:PORT:ADDRESS',
+    help="""
+    Force resolve of HOST:PORT to ADDRESS bypassing hosts file
+    (e.g. http --resolve "www.foo.com:127.0.0.1" GET www.foo.com/whatever).
+    ADDRESS is a comma-separated list of IP addresses, both IPv4 and IPv6
+    with or without bracket notation are supported
+    (e.g. --resolve example.org:80:[::2],[::1],127.0.0.1 is allowed).
+    This is similar to cURL --resolve option.
+    """
+)
 
 #######################################################################
 # SSL

--- a/httpie/core.py
+++ b/httpie/core.py
@@ -29,6 +29,7 @@ from httpie.output.streams import (
     write_stream,
     write_stream_with_colors_win_py3
 )
+from httpie.resolve import CustomResolver
 
 
 def get_exit_status(http_status, follow=False):
@@ -96,7 +97,9 @@ def program(args, env, log_error):
             )
             downloader.pre_request(args.headers)
 
-        final_response = get_response(args, config_dir=env.config.directory)
+        with CustomResolver(args.resolve):
+            final_response = get_response(args, config_dir=env.config.directory)
+
         if args.all:
             responses = final_response.history + [final_response]
         else:

--- a/httpie/resolve.py
+++ b/httpie/resolve.py
@@ -1,0 +1,53 @@
+import socket
+
+
+class CustomResolver:
+    def __init__(self, resolve):
+        """
+        :param resolve: A list of HOST[:PORT]:ADDRESS[:ADDRESS]? records
+        :type resolve: list[str]
+        """
+        self.entries = {}
+        for entry in resolve:
+            host, port_and_addresses = entry.split(':', 1)
+            if ':' in port_and_addresses:
+                port, addresses = port_and_addresses.split(':', 1)
+                try:
+                    port = int(port)
+                except ValueError:
+                    port = None
+                    addresses = port_and_addresses
+            else:
+                port = None
+                addresses = port_and_addresses
+
+            final_addresses = []
+            for address in addresses.split(','):
+                if address[:1] == '[' and address[-1:] == ']':
+                    address = address[1:-1]
+                final_addresses.append(address)
+            self.entries[(host, port)] = final_addresses
+
+    def getaddrinfo(self, host, port, family=None, socktype=None, proto=None, flags=None):
+        for key in [(host, port), (host, None)]:
+            if key in self.entries:
+                return [
+                    res
+                    for ip in self.entries[key]
+                    for res in self._original_getaddrinfo(ip, port, family, socktype, proto or 0, flags or 0)
+                ]
+        else:
+            v = self._original_getaddrinfo(host, port, family, socktype, proto or 0, flags or 0)
+            return v
+
+    def __enter__(self):
+        self._original_getaddrinfo = socket.getaddrinfo
+        if self.entries:
+                socket.getaddrinfo = lambda host, port, *args, **kwargs: self.getaddrinfo(host, port, *args, **kwargs)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        socket.getaddrinfo = self._original_getaddrinfo
+
+
+__all__ = ['CustomResolver']

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,0 +1,100 @@
+import pytest
+import socket
+import threading
+import time
+
+from httpie.resolve import CustomResolver
+
+try:
+    from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+except:
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+from utils import http
+
+
+class MockHTTPServer:
+    class MockHTTPRequestHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200, 'GOOD')
+
+    def __init__(self, ipv):
+        if ipv == 4:
+            self.host = '127.0.0.1'
+            self.address_family = socket.AF_INET
+        elif ipv == 6:
+            self.host = '::1'
+            self.address_family = socket.AF_INET6
+        else:
+            raise ValueError('Invalid ipv (%s), expected 4 or 6' % ipv)
+        self.port = self.get_free_port()
+
+        class _HTTPServer(HTTPServer):
+            address_family = self.address_family
+
+        self.mock_server = _HTTPServer((self.host, self.port), self.MockHTTPRequestHandler)
+        self.thread = threading.Thread(target=self._start)
+
+    def _start(self):
+        self.mock_server.serve_forever()
+
+    def get_free_port(self):
+        s = socket.socket(self.address_family, type=socket.SOCK_STREAM)
+        s.bind(('localhost', 0))
+        r = s.getsockname()
+        s.close()
+        return r[1]
+
+    def __enter__(self):
+        self.thread.setDaemon(True)
+        self.thread.start()
+        time.sleep(1.0)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.thread:
+            self.thread.join(1.0)
+
+
+@pytest.mark.parametrize('args,expected', [
+    (
+        ['a:80:127.0.0.1'],
+        {('a', 80): ['127.0.0.1']}
+    ),
+    (
+        ['a:127.0.0.1'],
+        {('a', None): ['127.0.0.1']}
+    ),
+    (
+        ['a:::1'],
+        {('a', None): ['::1']}
+    ),
+])
+def test_resolve_arg_parse(args, expected):
+    custom_resolver = CustomResolver(args)
+    assert custom_resolver.entries == expected
+
+
+class TestResolve:
+    def test_resolve_ipv4(self):
+        with MockHTTPServer(4) as mock_http_server:
+            r = http('http://httpbin.org:%s/' % mock_http_server.port,
+                     '--resolve', 'httpbin.org:%s:%s' % (mock_http_server.port, mock_http_server.host))
+            assert '200 GOOD' in r
+
+    def test_resolve_ipv6(self):
+        with MockHTTPServer(6) as mock_http_server:
+            r = http('http://httpbin.org:%s/' % mock_http_server.port,
+                     '--resolve', 'httpbin.org:%s:%s' % (mock_http_server.port, mock_http_server.host))
+            assert '200 GOOD' in r
+
+    def test_resolve_ipv6_and_ipv6(self):
+        with MockHTTPServer(6) as mock_http_server:
+            r = http('http://httpbin.org:%s/' % mock_http_server.port,
+                     '--resolve', 'httpbin.org:%s:[::2],%s' % (mock_http_server.port, mock_http_server.host))
+            assert '200 GOOD' in r
+
+    def test_resolve_ipv6_and_ipv4(self):
+        with MockHTTPServer(4) as mock_http_server:
+            r = http('http://httpbin.org:%s/' % mock_http_server.port,
+                     '--resolve', 'httpbin.org:%s:[::2],%s' % (mock_http_server.port, mock_http_server.host))
+            assert '200 GOOD' in r

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -55,23 +55,22 @@ class MockHTTPServer:
             self.thread.join(1.0)
 
 
-@pytest.mark.parametrize('args,expected', [
+@pytest.mark.parametrize('arg,expected', [
     (
-        ['a:80:127.0.0.1'],
-        {('a', 80): ['127.0.0.1']}
+        'a:80:127.0.0.1',
+        ('a', 80, ['127.0.0.1']),
     ),
     (
-        ['a:127.0.0.1'],
-        {('a', None): ['127.0.0.1']}
+        'a:127.0.0.1',
+        ('a', None, ['127.0.0.1']),
     ),
     (
-        ['a:::1'],
-        {('a', None): ['::1']}
+        'a:::1',
+        ('a', None, ['::1']),
     ),
 ])
-def test_resolve_arg_parse(args, expected):
-    custom_resolver = CustomResolver(args)
-    assert custom_resolver.entries == expected
+def test_resolve_arg_parse(arg, expected):
+    assert CustomResolver.parse_resolve_entry(arg) == expected
 
 
 class TestResolve:


### PR DESCRIPTION
Added `--resolve` option. Few points I'd like to get help with:
* Would all requests happen within the context of the `CustomResolver` being created in the `core.py:program`?
* What would be the best way to update `README.rst`?
* I've tried to provide a support for IPv6 without square brackets, so something like `--resolve example.org:::1,::2` would also work. Is that fine or square brackets syntax should be enforced so it would be mandatory to write something like `--resolve example.org:[::1],[::2]`?