### PR TITLE
Disable Auth Plugin

### DIFF
--- a/httpie/input.py
+++ b/httpie/input.py
@@ -238,7 +238,7 @@ class HTTPieArgumentParser(ArgumentParser):
                 self.args.auth_type = default_auth_plugin.auth_type
             plugin = plugin_manager.get_auth_plugin(self.args.auth_type)()
 
-            if plugin.auth_require and self.args.auth is None:
+            if plugin.auth_require and self.args.auth is None and self.args.auth_type != 'disabled':
                 self.error('--auth required')
 
             plugin.raw_auth = self.args.auth

--- a/httpie/plugins/__init__.py
+++ b/httpie/plugins/__init__.py
@@ -8,7 +8,7 @@ from httpie.plugins.base import (
     ConverterPlugin, TransportPlugin
 )
 from httpie.plugins.manager import PluginManager
-from httpie.plugins.builtin import BasicAuthPlugin, DigestAuthPlugin
+from httpie.plugins.builtin import BasicAuthPlugin, DigestAuthPlugin, DisableAuthPlugin
 from httpie.output.formatters.headers import HeadersFormatter
 from httpie.output.formatters.json import JSONFormatter
 from httpie.output.formatters.colors import ColorFormatter
@@ -16,7 +16,8 @@ from httpie.output.formatters.colors import ColorFormatter
 
 plugin_manager = PluginManager()
 plugin_manager.register(BasicAuthPlugin,
-                        DigestAuthPlugin)
+                        DigestAuthPlugin,
+                        DisableAuthPlugin)
 plugin_manager.register(HeadersFormatter,
                         JSONFormatter,
                         ColorFormatter)

--- a/httpie/plugins/builtin.py
+++ b/httpie/plugins/builtin.py
@@ -49,3 +49,13 @@ class DigestAuthPlugin(BuiltinAuthPlugin):
     # noinspection PyMethodOverriding
     def get_auth(self, username, password):
         return requests.auth.HTTPDigestAuth(username, password)
+
+
+class DisableAuthPlugin(BuiltinAuthPlugin):
+
+    name = 'Disable HTTP auth'
+    auth_type = 'disabled'
+
+    # noinspection PyMethodOverriding
+    def get_auth(self, username=None, password=None):
+        return None


### PR DESCRIPTION
Added a builtin plugin to explicitly disable HTTP authentication and send an empty authorization header.