### PR TITLE
Add option to trim extension from downloaded file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1353,7 +1353,7 @@ To prevent data loss by overwriting, HTTPie adds a unique numerical suffix to th
 filename when necessary (unless specified with ``--output, -o``).
 
 To trim extension from downloaded file name it is possible to specify 
-``--trim-ext` flag.
+``--trim-ext`` flag.
 
 
 Piping while downloading

--- a/README.rst
+++ b/README.rst
@@ -1352,6 +1352,9 @@ the output filename (with decreasing priority):
 To prevent data loss by overwriting, HTTPie adds a unique numerical suffix to the
 filename when necessary (unless specified with ``--output, -o``).
 
+To trim extension from downloaded file name it is possible to specify 
+``--trim-ext` flag.
+
 
 Piping while downloading
 ------------------------

--- a/httpie/cli/definition.py
+++ b/httpie/cli/definition.py
@@ -350,6 +350,15 @@ output_options.add_argument(
 )
 
 output_options.add_argument(
+    '--trim-ext',
+    action='store_true',
+    default=False,
+    help="""
+    Trims extension from downloaded file name
+    """
+)
+
+output_options.add_argument(
     '--continue', '-c',
     dest='download_resume',
     action='store_true',

--- a/httpie/core.py
+++ b/httpie/core.py
@@ -127,7 +127,8 @@ def program(
             downloader = Downloader(
                 output_file=args.output_file,
                 progress_file=env.stderr,
-                resume=args.download_resume
+                resume=args.download_resume,
+                options={'trim_ext': args.trim_ext}
             )
             downloader.pre_request(args.headers)
 

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -64,6 +64,16 @@ class TestDownloadUtils:
             url='http://example.org/foo',
             content_type='text/plain'
         )
+        assert 'foo' == filename_from_url(
+            url='http://example.org/foo',
+            content_type='text/plain',
+            options={'trim_ext': True}
+        )
+        assert 'foo.txt' == filename_from_url(
+            url='http://example.org/foo',
+            content_type='text/plain',
+            options={'trim_ext': False}
+        )
         assert 'foo.html' == filename_from_url(
             url='http://example.org/foo',
             content_type='text/html; charset=utf8'


### PR DESCRIPTION
#689 
I’m not sure that this issue is still relevant, but anyway - I propose such a fix.
Specifying a flag only for TXT would be too wasteful, I see that forcing trimming the extension can be useful in any other case, even when we can guess the extension by the content type.