### PR TITLE
Cookie redirect update fix 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 * Added ``--ciphers`` to allow configuring OpenSSL ciphers (`#870`_).
 * Added support for ``$XDG_CONFIG_HOME`` (`#920`_).
 * Added support for custom content types for uploaded files (`#668`_).
-
+* Fixed cookie not updated during redirect by saving domain for cookies (`#662`).
 
 `2.1.0`_ (2020-04-18)
 ---------------------

--- a/httpie/sessions.py
+++ b/httpie/sessions.py
@@ -103,7 +103,7 @@ class Session(BaseConfigDict):
     @cookies.setter
     def cookies(self, jar: RequestsCookieJar):
         # <https://docs.python.org/2/library/cookielib.html#cookie-objects>
-        stored_attrs = ['value', 'path', 'secure', 'expires']
+        stored_attrs = ['value', 'domain', 'path', 'secure', 'expires']
         self['cookies'] = {}
         for cookie in jar:
             self['cookies'][cookie.name] = {

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -75,10 +75,13 @@ class TestSessionFlow(SessionTestBase):
 
         # Make a request modifying the session data.
         r3 = http('--follow', '--session=test', '--auth=username:password2',
-                  'GET', httpbin.url + '/cookies/set?hello=world2',
-                  'Hello:World2',
+                  '--print=Hhb', 'GET',
+                  httpbin.url + '/cookies/set?hello=world2', 'Hello:World2',
                   env=self.env())
         assert HTTP_OK in r3
+
+        # https://github.com/jakubroztocil/httpie/issues/662
+        assert 'Cookie: hello=world2' in r3
 
         # Get a response to a request from the updated session.
         r4 = http('--session=test', 'GET', httpbin.url + '/get',


### PR DESCRIPTION
Fixes #662 

The crux of the bug is that `httpie` was not saving the domain of the cookie. As a result, when a session was loaded from a file and a request was sent to a server that sets a new cookie of the same name, its value would not be overwritten.

I have not written tests for this. I think there are two relevant things that need to be tested:

1. Testing that cookies from different domains do not overwrite each other
2. Testing that the headers are correct

I am not exactly sure how to test 1 as it seems to me that everything is happening locally with httpbin so direction would be appreciated. As for 2, my original idea was to write a parser for the headers in `BaseCLIResponse` and to make assertions on the request header in `test_session_update`. 

Is this a good idea?