### PR TITLE
Add workflow to test with pyOpenSSL active

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-      - run: python -m pip install --upgrade pip
+      - run: pip install --upgrade pip setuptools wheel
       - run: pip install --upgrade --editable .
       - run: python setup.py test
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8]
+        pyopenssl: ["0", "1"]
         exclude:
           - os: windows-latest
             python-version: 3.8
@@ -32,6 +33,8 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install --upgrade pip setuptools wheel
+      - run: python -m pip install --upgrade pip
       - run: pip install --upgrade --editable .
       - run: python setup.py test
+        env:
+          HTTPIE_TEST_WITH_PYOPENSSL: ${{ matrix.pyopenssl }}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ docutils
 wheel
 pycodestyle
 twine
+pyopenssl

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ class PyTest(TestCommand):
 tests_require = [
     'pytest-httpbin',
     'pytest',
+    'pyopenssl',
     'mock',
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from pytest_httpbin import certs
 
@@ -22,3 +23,19 @@ def httpbin_secure_untrusted(monkeypatch, httpbin_secure):
     """
     monkeypatch.delenv('REQUESTS_CA_BUNDLE')
     return httpbin_secure
+
+
+@pytest.fixture(autouse=True, scope='session')
+def pyopenssl_inject():
+    """
+    Injects `pyOpenSSL` module to make sure `requests`
+    will use it.
+
+    <https://github.com/psf/requests/pull/5443#issuecomment-645740394>
+    """
+
+    if os.getenv('HTTPIE_TEST_WITH_PYOPENSSL', default='0') != '1':
+        return
+
+    import urllib3.contrib.pyopenssl
+    urllib3.contrib.pyopenssl.inject_into_urllib3()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,9 +33,11 @@ def pyopenssl_inject():
 
     <https://github.com/psf/requests/pull/5443#issuecomment-645740394>
     """
-
-    if os.getenv('HTTPIE_TEST_WITH_PYOPENSSL', default='0') != '1':
-        return
-
     import urllib3.contrib.pyopenssl
     urllib3.contrib.pyopenssl.inject_into_urllib3()
+
+    if os.getenv('HTTPIE_TEST_WITH_PYOPENSSL', default='0') == '0':
+        urllib3.contrib.pyopenssl.extract_from_urllib3()
+
+    yield
+    urllib3.contrib.pyopenssl.extract_from_urllib3()

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1,6 +1,8 @@
+import os
 import pytest
 import pytest_httpbin.certs
 import requests.exceptions
+import urllib3
 
 from httpie.ssl import AVAILABLE_SSL_VERSION_ARG_MAPPING, DEFAULT_SSL_CIPHERS
 from httpie.status import ExitStatus
@@ -138,3 +140,17 @@ def test_ciphers_none_can_be_selected(httpbin_secure):
     #   <https://marc.info/?l=openbsd-ports&m=159251948515635&w=2>
     #   http: error: Error: [('SSL routines', '(UNKNOWN)SSL_internal', 'no cipher match')]
     assert 'cipher' in r.stderr
+
+
+def test_pyopenssl():
+    env_with_pyopenssl = os.getenv('HTTPIE_TEST_WITH_PYOPENSSL', default='0')
+
+    assert env_with_pyopenssl == '0' or env_with_pyopenssl == '1'
+
+    if env_with_pyopenssl == '0':
+        assert urllib3.util.ssl_.IS_PYOPENSSL is False
+        assert urllib3.util.IS_PYOPENSSL is False
+
+    elif env_with_pyopenssl == '1':
+        assert urllib3.util.ssl_.IS_PYOPENSSL is True
+        assert urllib3.util.IS_PYOPENSSL is True


### PR DESCRIPTION
Monkeypatches the `pyOpenSSL` module using [`urllib3.contrib.pyopenssl.inject_into_urllib3()`](https://github.com/urllib3/urllib3/blob/master/src/urllib3/contrib/pyopenssl.py#L20-L30). Testing is done using an environment variable (`HTTPIE_TEST_WITH_OPENSSL`) which, if enabled (`HTTPIE_TEST_WITH_OPENSSL="1"`), will trigger a pytest fixture to do the monkeypatching.

Fixes #939.