### PR TITLE
provide password via environment variable `HTTPIE_PASSWORD`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 * Added support for combining cookies specified on the CLI and in a session file (`#932`_).
 * Added out of the box SOCKS support with no extra installation (`#904`_).
 * Removed Tox testing entirely (`#943`_).
+* Provide password via environment variable ``HTTPIE_PASSWORD``
 
 
 `2.2.0`_ (2020-06-18)

--- a/README.rst
+++ b/README.rst
@@ -918,6 +918,17 @@ Empty password
     $ http -a username: httpbin.org/headers
 
 
+Environment variable
+--------------------
+
+A password can also be provided via environment variable ``HTTPIE_PASSWORD``.
+The env password is ignored if the password is provided as an argument as well.
+
+.. code-block:: bash
+
+    $ HTTPIE_PASSWORD=password http -a username httpbin.org/basic-auth/username/password
+
+
 ``.netrc``
 ----------
 

--- a/httpie/cli/argparser.py
+++ b/httpie/cli/argparser.py
@@ -216,15 +216,19 @@ class HTTPieArgumentParser(argparse.ArgumentParser):
                 else:
                     credentials = parse_auth(self.args.auth)
 
-                if (not credentials.has_password()
-                        and plugin.prompt_password):
-                    if self.args.ignore_stdin:
-                        # Non-tty stdin read by now
-                        self.error(
-                            'Unable to prompt for passwords because'
-                            ' --ignore-stdin is set.'
-                        )
-                    credentials.prompt_password(url.netloc)
+                if not credentials.has_password():
+                    env_password = os.getenv("HTTPIE_PASSWORD")
+
+                    if env_password is not None:
+                        credentials.value = env_password
+                    elif plugin.prompt_password:
+                        if self.args.ignore_stdin:
+                            # Non-tty stdin read by now
+                            self.error(
+                                'Unable to prompt for passwords because'
+                                ' --ignore-stdin is set.'
+                            )
+                        credentials.prompt_password(url.netloc)
                 self.args.auth = plugin.get_auth(
                     username=credentials.key,
                     password=credentials.value,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -34,6 +34,18 @@ def test_password_prompt(httpbin):
     assert r.json == {'authenticated': True, 'user': 'user'}
 
 
+def test_password_from_env(httpbin):
+    import os
+    os.environ["HTTPIE_PASSWORD"] = "password"
+    try:
+        r = http('--auth', 'user',
+                 'GET', httpbin.url + '/basic-auth/user/password')
+        assert HTTP_OK in r
+        assert r.json == {'authenticated': True, 'user': 'user'}
+    finally:
+        del os.environ["HTTPIE_PASSWORD"]
+
+
 def test_credentials_in_url(httpbin_both):
     url = add_auth(httpbin_both.url + '/basic-auth/user/password',
                    auth='user:password')


### PR DESCRIPTION
This is a reviving #229 which enables passing of the auth password as environment variable.

The original pr had unfixed cr comments and was never addressed and was ultimately retracted it seems.
The initial comments are addressed in this pr.
If there are other comments related to this change I'm happy to fix them.

Solves my use case; in this pr:

- add support for auth password as env `HTTPIE_PASSWORD`
- add test (`make test-all` fine)
- update docs
- update changelog
