### PR TITLE
Working towards HTTP/2 - `httpcore` approach.

### DIFF
--- a/httpie/adapters.py
+++ b/httpie/adapters.py
@@ -1,0 +1,82 @@
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util import parse_url
+from urllib3.response import HTTPResponse
+from httpcore import SyncConnectionPool, PlainByteStream
+
+
+class FileLike:
+    def __init__(self, bytestream):
+        self._bytestream = iter(bytestream)
+        self.closed = False
+
+    def read(self, amt: int = None):
+        return next(self._bytestream, b"")
+
+    def close(self):
+        self._bytestream.close()
+        self.closed = True
+
+
+class StreamLike:
+    def __init__(self, filelike):
+        self._filelike = filelike
+
+    def __iter__(self):
+        chunk = self._filelike.read(4096)
+        while chunk:
+            yield chunk
+            chunk = self._filelike.read(4096)
+
+    def close():
+        pass
+
+
+class HTTPCoreAdapter(HTTPAdapter):
+    def __init__(self):
+        self.pool = SyncConnectionPool()
+
+    def send(self, request, stream=False, timeout=None, verify=True,
+             cert=None, proxies=None):
+        method = request.method.encode("ascii")
+
+        parsed = parse_url(request.url)
+        scheme = parsed.scheme.encode("ascii")
+        host = parsed.host.encode("ascii")
+        port = parsed.port
+        target = parsed.path.encode("ascii")
+        if parsed.query:
+            target += b"?" + parsed.query.encode("ascii")
+        url = (scheme, host, port, target)
+
+        headers = [(b'Host', parsed.netloc.encode("ascii"))]
+        headers.extend([
+            (key, val) for key, val in request.headers.items()
+        ])
+
+        if not request.body:
+            stream = PlainByteStream(b"")
+        elif isinstance(request.body, str):
+            stream = PlainByteStream(request.body.encode("utf-8"))
+        elif isinstance(request.body, bytes):
+            stream = PlainByteStream(request.body)
+        else:
+            stream = StreamLike(request.body)
+
+        ext = {}
+
+        status_code, headers, stream, ext = self.pool.request(method, url, headers, stream, ext)
+
+        urllib3_response = HTTPResponse(
+            body=FileLike(stream),
+            headers=[(key.decode("ascii"), val.decode("ascii")) for key, val in headers],
+            status=status_code,
+            reason=ext['reason'],
+            version={'HTTP/0.9': 9, 'HTTP/1.0': 10, 'HTTP/1.1': 11, 'HTTP/2': 20}[ext['http_version']],
+            preload_content=False,
+        )
+
+        return self.build_response(request, urllib3_response)
+
+    def close(self):
+        self.pool.close()

--- a/httpie/client.py
+++ b/httpie/client.py
@@ -149,7 +149,6 @@ def compress_body(request: requests.PreparedRequest, always: bool):
     deflated_data += deflater.flush()
     is_economical = len(deflated_data) < len(body_bytes)
     if is_economical or always:
-        print(request.body, repr(deflated_data), len(request.body), len(deflated_data))
         request.body = deflated_data
         request.headers['Content-Encoding'] = 'deflate'
         request.headers['Content-Length'] = str(len(deflated_data))

--- a/httpie/models.py
+++ b/httpie/models.py
@@ -52,26 +52,26 @@ class HTTPResponse(HTTPMessage):
     # noinspection PyProtectedMember
     @property
     def headers(self):
-        original = self._orig.raw._original_response
+        raw = self._orig.raw
 
         version = {
             9: '0.9',
             10: '1.0',
             11: '1.1',
             20: '2',
-        }[original.version]
+        }[raw.version]
 
-        status_line = f'HTTP/{version} {original.status} {original.reason}'
+        status_line = f'HTTP/{version} {raw.status} {raw.reason}'
         headers = [status_line]
         try:
             # `original.msg` is a `http.client.HTTPMessage` on Python 3
             # `_headers` is a 2-tuple
             headers.extend(
-                '%s: %s' % header for header in original.msg._headers)
+                '%s: %s' % header for header in raw.headers.items())
         except AttributeError:
             # and a `httplib.HTTPMessage` on Python 2.x
             # `headers` is a list of `name: val<CRLF>`.
-            headers.extend(h.strip() for h in original.msg.headers)
+            headers.extend(h.strip() for h in raw.headers)
 
         return '\r\n'.join(headers)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -133,7 +133,7 @@ class StrCLIResponse(str, BaseCLIResponse):
             elif self.strip().startswith('{'):
                 # Looks like JSON body.
                 self._json = json.loads(self)
-            elif (self.count('Content-Type:') == 1
+            elif (self.count('content-type:') == 1
                     and 'application/json' in self):
                 # Looks like a whole JSON HTTP message,
                 # try to extract its body.


### PR DESCRIPTION
This PR is a piece of exploratory work around replacing the existing `urlib3`-based adapter with an `httpcore`-based adapter.

The motivation behind this is to allow `httpie` to add HTTP/2 support, with a minimal change footprint.

Haven't yet worked through all the test cases on this, but opening this up as a starting point.