### PR TITLE
Support directory input for --output

### DIFF
--- a/httpie/cli/argparser.py
+++ b/httpie/cli/argparser.py
@@ -213,8 +213,8 @@ class HTTPieArgumentParser(argparse.ArgumentParser):
 
         if self.args.quiet:
             self.env.stderr = self.env.devnull
-            if not (self.args.output_dest_specified and
-                    not self.args.download):
+            if not (self.args.output_dest_specified
+                    and not self.args.download):
                 self.env.stdout = self.env.devnull
 
     def _process_auth(self):

--- a/httpie/cli/argparser.py
+++ b/httpie/cli/argparser.py
@@ -183,10 +183,6 @@ class HTTPieArgumentParser(argparse.ArgumentParser):
 
         if self.args.download:
             # FIXME: Come up with a cleaner solution.
-            # self.output_filename = get_unique_filename(
-                # get_initial_filename(self.args.url)
-            # )
-            # self.output_file = open(self.output_filename, 'a+b')
             if not self.args.output_dest and not self.env.stdout_isatty:
                 # Use stdout as the download output file.
                 self.output_file = self.env.stdout
@@ -217,7 +213,8 @@ class HTTPieArgumentParser(argparse.ArgumentParser):
 
         if self.args.quiet:
             self.env.stderr = self.env.devnull
-            if not (self.args.output_dest_specified and not self.args.download):
+            if not (self.args.output_dest_specified and
+                    not self.args.download):
                 self.env.stdout = self.env.devnull
 
     def _process_auth(self):
@@ -475,5 +472,7 @@ class HTTPieArgumentParser(argparse.ArgumentParser):
     def _process_format_options(self):
         parsed_options = PARSED_DEFAULT_FORMAT_OPTIONS
         for options_group in self.args.format_options or []:
-            parsed_options = parse_format_options(options_group, defaults=parsed_options)
+            parsed_options = parse_format_options(
+                options_group, defaults=parsed_options
+            )
         self.args.format_options = parsed_options

--- a/httpie/cli/argparser.py
+++ b/httpie/cli/argparser.py
@@ -25,7 +25,10 @@ from httpie.cli.exceptions import ParseError
 from httpie.cli.requestitems import RequestItems
 from httpie.context import Environment
 from httpie.plugins.registry import plugin_manager
-from httpie.utils import ExplicitNullAuth, get_content_type
+from httpie.utils import (
+    ExplicitNullAuth, get_content_type, get_initial_filename,
+    get_unique_filename
+)
 
 
 class HTTPieHelpFormatter(RawDescriptionHelpFormatter):
@@ -63,6 +66,7 @@ class HTTPieArgumentParser(argparse.ArgumentParser):
         super().__init__(*args, formatter_class=formatter_class, **kwargs)
         self.env = None
         self.args = None
+        self.output_file = None
         self.has_stdin_data = False
 
     # noinspection PyMethodOverriding
@@ -145,23 +149,47 @@ class HTTPieArgumentParser(argparse.ArgumentParser):
             message = message.encode(self.env.stdout_encoding)
         super()._print_message(message, file)
 
+    @property
+    def _output_file(self):
+        return self.output_file
+
     def _setup_standard_streams(self):
         """
         Modify `env.stdout` and `env.stdout_isatty` based on args, if needed.
 
         """
-
+        self.output_file = False
         self.args.output_dest_specified = bool(self.args.output_dest)
-        self.output_dest = self.args.output_dest
-        if not os.path.isdir(self.output_dest):
-            self.output_file = open(self.output_dest, 'a+b')
-            self.args.output_file = self.output_file
+        if self.args.output_dest_specified:
+            if not os.path.isdir(self.args.output_dest):
+                try:
+                    # directly open the output file provided
+                    self.output_file = open(self.args.output_dest, 'a+b')
+                except IsADirectoryError:
+                    self.error('The specified directory does not exist')
+            else:
+                # directory passed as output destination
+                self.output_filename = get_initial_filename(self.args.url)
+                if not self.args.download_resume:
+                    self.output_file_path = get_unique_filename(
+                        os.path.join(self.args.output_dest,
+                                     self.output_filename)
+                    )
+                else:
+                    self.output_file_path = os.path.join(
+                        self.args.output_dest, self.output_filename
+                    )
+                self.output_file = open(self.output_file_path, 'a+b')
 
         if self.args.download:
             # FIXME: Come up with a cleaner solution.
-            if not self.output_dest and not self.env.stdout_isatty:
+            # self.output_filename = get_unique_filename(
+                # get_initial_filename(self.args.url)
+            # )
+            # self.output_file = open(self.output_filename, 'a+b')
+            if not self.args.output_dest and not self.env.stdout_isatty:
                 # Use stdout as the download output file.
-                self.args.output_dest = self.env.stdout
+                self.output_file = self.env.stdout
             # With `--download`, we write everything that would normally go to
             # `stdout` to `stderr` instead. Let's replace the stream so that
             # we don't have to use many `if`s throughout the codebase.
@@ -169,22 +197,23 @@ class HTTPieArgumentParser(argparse.ArgumentParser):
             self.env.stdout = self.env.stderr
             self.env.stdout_isatty = self.env.stderr_isatty
 
-        elif self.output_dest:
+        elif self.args.output_dest_specified:
             # When not `--download`ing, then `--output` simply replaces
             # `stdout`. The file is opened for appending, which isn't what
             # we want in this case.
-            if not os.path.isdir(self.output_dest):
-                self.args.output_dest.seek(0)
-                try:
-                    self.args.output_dest.truncate()
-                except IOError as e:
-                    if e.errno == errno.EINVAL:
-                        # E.g. /dev/null on Linux.
-                        pass
-                    else:
-                        raise
-            self.env.stdout = self.args.output_dest
+            self.output_file.seek(0)
+            try:
+                self.output_file.truncate()
+            except IOError as e:
+                if e.errno == errno.EINVAL:
+                    # E.g. /dev/null on Linux.
+                    pass
+                else:
+                    raise
+            self.env.stdout = self.output_file
             self.env.stdout_isatty = False
+
+        self.args.output_dest = self._output_file
 
         if self.args.quiet:
             self.env.stderr = self.env.devnull

--- a/httpie/cli/definition.py
+++ b/httpie/cli/definition.py
@@ -415,7 +415,7 @@ output_options.add_argument(
 )
 output_options.add_argument(
     '--output', '-o',
-    type=FileType('a+b'),
+    type=str,
     dest='output_file',
     metavar='FILE',
     help='''

--- a/httpie/cli/definition.py
+++ b/httpie/cli/definition.py
@@ -2,7 +2,7 @@
 CLI arguments definition.
 
 """
-from argparse import (FileType, OPTIONAL, SUPPRESS, ZERO_OR_MORE)
+from argparse import (OPTIONAL, SUPPRESS, ZERO_OR_MORE)
 from textwrap import dedent, wrap
 
 from httpie import __doc__, __version__

--- a/httpie/cli/definition.py
+++ b/httpie/cli/definition.py
@@ -416,12 +416,12 @@ output_options.add_argument(
 output_options.add_argument(
     '--output', '-o',
     type=str,
-    dest='output_file',
+    dest='output_dest',
     metavar='FILE',
     help='''
-    Save output to FILE instead of stdout. If --download is also set, then only
-    the response body is saved to FILE. Other parts of the HTTP exchange are
-    printed to stderr.
+    Save output to a FILE or create it inside a DIRECTORY instead of stdout.
+    If --download is also set, then only the response body is saved to FILE.
+    Other parts of the HTTP exchange are printed to stderr.
 
     '''
 

--- a/httpie/core.py
+++ b/httpie/core.py
@@ -256,7 +256,7 @@ def program(
 
         if (not isinstance(args, list) and args.output_file
                 and args.output_file_specified):
-            args.output_file.close()
+            downloader.output_file.close()
 
 
 def print_debug_info(env: Environment):

--- a/httpie/core.py
+++ b/httpie/core.py
@@ -149,7 +149,7 @@ def program(
         if args.download:
             args.follow = True  # --download implies --follow.
             downloader = Downloader(
-                output_file=args.output_file,
+                output_dest=args.output_dest,
                 progress_file=env.stderr,
                 resume=args.download_resume
             )
@@ -254,8 +254,8 @@ def program(
         if downloader and not downloader.finished:
             downloader.failed()
 
-        if (not isinstance(args, list) and args.output_file
-                and args.output_file_specified):
+        if (not isinstance(args, list) and args.output_dest
+                and args.output_dest_specified):
             downloader.output_file.close()
 
 

--- a/httpie/core.py
+++ b/httpie/core.py
@@ -149,11 +149,11 @@ def program(
         if args.download:
             args.follow = True  # --download implies --follow.
             downloader = Downloader(
-                output_dest=args.output_dest,
+                output_file=args.output_dest,
                 progress_file=env.stderr,
                 resume=args.download_resume
             )
-            downloader.pre_request(args.headers)
+            downloader.pre_request(args.url, args.headers)
 
         needs_separator = False
 
@@ -256,7 +256,7 @@ def program(
 
         if (not isinstance(args, list) and args.output_dest
                 and args.output_dest_specified):
-            downloader.output_file.close()
+            args.output_dest.close()
 
 
 def print_debug_info(env: Environment):

--- a/httpie/downloads.py
+++ b/httpie/downloads.py
@@ -5,14 +5,13 @@ Download mode implementation.
 """
 from __future__ import division
 
-import errno
 import os
 import re
 import sys
 import requests
 import threading
 from time import sleep, time
-from typing import IO, Optional, Tuple
+from typing import IO, Tuple
 
 from httpie.models import HTTPResponse
 from httpie.output.streams import RawStream
@@ -167,7 +166,6 @@ class Downloader:
             total_size = int(final_response.headers['Content-Length'])
         except (KeyError, ValueError, TypeError):
             total_size = None
-
 
         if not self._output_file:
             # create download output file

--- a/httpie/utils.py
+++ b/httpie/utils.py
@@ -1,7 +1,7 @@
 from __future__ import division
 
 import os
-import sys
+import errno
 import json
 import mimetypes
 from mailbox import Message
@@ -200,9 +200,11 @@ def trim_filename_if_needed(filename: str, directory='.', extra=0) -> str:
 def get_initial_filename(url: str):
     try:
         headers = requests.head(url, allow_redirects=True).headers
-    except Exception as e:
-         filename = filename_from_url(url, '')
-         return filename
+    except Exception:
+        # If there's an error while making request here,
+        # return the default filename and handle the error on the main request
+        filename = filename_from_url(url, '')
+        return filename
 
     filename = filename_from_url(url, headers["Content-Type"])
     content_disposition = None

--- a/httpie/utils.py
+++ b/httpie/utils.py
@@ -1,12 +1,16 @@
 from __future__ import division
 
+import os
+import sys
 import json
 import mimetypes
+from mailbox import Message
 import time
 from collections import OrderedDict
 from http.cookiejar import parse_ns_headers
 from pprint import pformat
 from typing import List, Optional, Tuple
+from urllib.parse import urlsplit
 
 import requests.auth
 
@@ -117,3 +121,104 @@ def get_expired_cookies(
         for cookie in cookies
         if is_expired(expires=cookie.get('expires'))
     ]
+
+
+def filename_from_content_disposition(
+    content_disposition: str
+) -> Optional[str]:
+    """
+    Extract and validate filename from a Content-Disposition header.
+
+    :param content_disposition: Content-Disposition value
+    :return: the filename if present and valid, otherwise `None`
+
+    """
+    # attachment; filename=jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz
+
+    msg = Message('Content-Disposition: %s' % content_disposition)
+    filename = msg.get_filename()
+    if filename:
+        # Basic sanitation.
+        filename = os.path.basename(filename).lstrip('.').strip()
+        if filename:
+            return filename
+
+
+def filename_from_url(url: str, content_type: Optional[str]) -> str:
+    fn = urlsplit(url).path.rstrip('/')
+    fn = os.path.basename(fn) if fn else 'index'
+    if '.' not in fn and content_type:
+        content_type = content_type.split(';')[0]
+        if content_type == 'text/plain':
+            # mimetypes returns '.ksh'
+            ext = '.txt'
+        else:
+            ext = mimetypes.guess_extension(content_type)
+
+        if ext == '.htm':  # Python 3
+            ext = '.html'
+
+        if ext:
+            fn += ext
+
+    return fn
+
+
+def trim_filename(filename: str, max_len: int) -> str:
+    if len(filename) > max_len:
+        trim_by = len(filename) - max_len
+        name, ext = os.path.splitext(filename)
+        if trim_by >= len(name):
+            filename = filename[:-trim_by]
+        else:
+            filename = name[:-trim_by] + ext
+    return filename
+
+
+def get_filename_max_length(directory: str) -> int:
+    max_len = 255
+    try:
+        pathconf = os.pathconf
+    except AttributeError:
+        pass  # non-posix
+    else:
+        try:
+            max_len = pathconf(directory, 'PC_NAME_MAX')
+        except OSError as e:
+            if e.errno != errno.EINVAL:
+                raise
+    return max_len
+
+
+def trim_filename_if_needed(filename: str, directory='.', extra=0) -> str:
+    max_len = get_filename_max_length(directory) - extra
+    if len(filename) > max_len:
+        filename = trim_filename(filename, max_len)
+    return filename
+
+
+def get_initial_filename(url: str):
+    try:
+        headers = requests.head(url, allow_redirects=True).headers
+    except Exception as e:
+         filename = filename_from_url(url, '')
+         return filename
+
+    filename = filename_from_url(url, headers["Content-Type"])
+    content_disposition = None
+    if "Content-Disposition" in headers:
+        content_disposition = headers["Content-Disposition"]
+        filename = filename_from_content_disposition(content_disposition)
+    filename = trim_filename_if_needed(filename)
+    return filename
+
+
+def get_unique_filename(filename: str, exists=os.path.exists) -> str:
+    attempt = 0
+    while True:
+        suffix = '-' + str(attempt) if attempt > 0 else ''
+        try_filename = trim_filename_if_needed(filename, extra=len(suffix))
+        try_filename += suffix
+        if not exists(try_filename):
+            return try_filename
+        attempt += 1

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -231,4 +231,3 @@ class TestDownloads:
                 assert os.listdir('.') == [expected_filename]
             finally:
                 os.chdir(orig_cwd)
-


### PR DESCRIPTION
Resolves #789.

The following implementation would allow users to provide directories as well as files for the `--output` option's value.
It works this way for the following cases:
- With `http -do <directory> <url>`, it creates the download file inside the given directory using the same file naming logic as before.
- With `http -dco <directory> <url>`, it searches for the file to continue inside the directory provided, using the name that would have been created during download.
- With `http -o <directory> <url>`, it creates the output file inside the given directory using the same naming logic as downloaded file name.

An error is raised in case a non-existing directory is passed.
**The existing behavior of passing a file as `--output` is still the same.**