### PR TITLE
Displaying error for incomplete responses

### DIFF
--- a/httpie/core.py
+++ b/httpie/core.py
@@ -220,7 +220,6 @@ def program(
                             level='warning'
                         )
 
-
                 if not downloader:
                     # repeating check for check_status specific
                     if(message.headers.get("Content-Length") and int(message.headers.get("Content-Length")) != len(message.content or "")):
@@ -231,7 +230,6 @@ def program(
                             ),
                             level='error'
                         )
-
 
             write_message(
                 requests_message=message,

--- a/httpie/core.py
+++ b/httpie/core.py
@@ -219,6 +219,20 @@ def program(
                             f'HTTP {message.raw.status} {message.raw.reason}',
                             level='warning'
                         )
+
+
+                if not downloader:
+                    # repeating check for check_status specific
+                    if(message.headers.get("Content-Length") and int(message.headers.get("Content-Length")) != len(message.content or "")):
+                        env.log_error(
+                            'Incomplete read: size=%d; read=%d' % (
+                                int(message.headers.get("Content-Length")),
+                                len(message.content)
+                            ),
+                            level='error'
+                        )
+
+
             write_message(
                 requests_message=message,
                 env=env,


### PR DESCRIPTION
In response to issue #965. A simple addition that compares the content-length header and response length. Apologies if there is a better solution as I am still exploring this project.

Continuing the test from the issue... 
```
$ http GET :8080/
http: error: Incomplete read: size=10; read=6

HTTP/1.1 200 OK
Content-Length: 10

123456
```