### PR TITLE
Decode headers using utf-8 only if they are not str

### DIFF
--- a/httpie/sessions.py
+++ b/httpie/sessions.py
@@ -77,7 +77,9 @@ class Session(BaseConfigDict):
             if value is None:
                 continue  # Ignore explicitly unset headers
 
-            value = value.decode('utf8')
+            if type(value) is not str:
+                value = value.decode('utf8')
+
             if name.lower() == 'user-agent' and value.startswith('HTTPie/'):
                 continue
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -16,6 +16,7 @@ from httpie.sessions import Session
 from httpie.utils import get_expired_cookies
 from tests.test_auth_plugins import basic_auth
 from utils import HTTP_OK, MockEnvironment, http, mk_config_dir
+from fixtures import FILE_PATH_ARG
 
 
 class SessionTestBase:
@@ -160,6 +161,12 @@ class TestSession(SessionTestBase):
         assert HTTP_OK in r2
         assert 'Content-Type' not in r2.json['headers']
         assert 'If-Unmodified-Since' not in r2.json['headers']
+
+    def test_session_with_upload(self, httpbin):
+        self.start_session(httpbin)
+        r = http('--session=test', '--form', '--verbose', 'POST', httpbin.url + '/post',
+                 f'test-file@{FILE_PATH_ARG}', 'foo=bar', env=self.env())
+        assert HTTP_OK in r
 
     def test_session_by_path(self, httpbin):
         self.start_session(httpbin)


### PR DESCRIPTION
httpie showed a strange behavior whenever I was using sessions with files uploads using multipart forms, returning the following error during execution:

```bash
http: error: AttributeError: 'str' object has no attribute 'decode'
```

So, I tested with debug:

```bash
> http --debug --session=test -f POST pie.dev/post name='John Smith' cv@~/files/data.xml
HTTPie 2.3.0
Requests 2.25.1
Pygments 2.7.4
Python 3.7.3 (default, Jul 25 2020, 13:03:44) 
[GCC 8.3.0]
/usr/bin/python3
Linux 4.19.0-13-amd64

<Environment {'colors': 256,
 'config': {'__meta__': {'about': 'HTTPie configuration file',
                         'help': 'https://httpie.org/docs#config',
                         'httpie': '0.9.8'},
            'default_options': []},
 'config_dir': PosixPath('/home/gian/.httpie'),
 'devnull': <property object at 0x7f8f26114e08>,
 'is_windows': False,
 'log_error': <function Environment.log_error at 0x7f8f26042378>,
 'program_name': 'http',
 'stderr': <_io.TextIOWrapper name='<stderr>' mode='w' encoding='UTF-8'>,
 'stderr_isatty': True,
 'stdin': <_io.TextIOWrapper name='<stdin>' mode='r' encoding='UTF-8'>,
 'stdin_encoding': 'UTF-8',
 'stdin_isatty': True,
 'stdout': <_io.TextIOWrapper name='<stdout>' mode='w' encoding='UTF-8'>,
 'stdout_encoding': 'UTF-8',
 'stdout_isatty': True}>

http: error: AttributeError: 'str' object has no attribute 'decode'

Traceback (most recent call last):
  File "/home/gian/.local/bin/http", line 8, in <module>
    sys.exit(main())
  File "/home/gian/.local/lib/python3.7/site-packages/httpie/__main__.py", line 11, in main
    exit_status = main()
  File "/home/gian/.local/lib/python3.7/site-packages/httpie/core.py", line 81, in main
    env=env,
  File "/home/gian/.local/lib/python3.7/site-packages/httpie/core.py", line 196, in program
    for message in messages:
  File "/home/gian/.local/lib/python3.7/site-packages/httpie/client.py", line 63, in collect_messages
    httpie_session.update_headers(request_kwargs['headers'])
  File "/home/gian/.local/lib/python3.7/site-packages/httpie/sessions.py", line 80, in update_headers
    value = value.decode('utf8')
AttributeError: 'str' object has no attribute 'decode'
```

After some investigation, I noticed the error was generated from the usage of the header returned from [get_multipart_data_and_content_type](https://github.com/httpie/httpie/blob/44ae67685d1eb184071899c9e0b7a0dd5d5cb9a5/httpie/uploads.py#L101-L118) containing the `Content-Type` header for the multipart form, which returns an encoder and the header as a string, at [collect_messages](https://github.com/httpie/httpie/blob/44ae67685d1eb184071899c9e0b7a0dd5d5cb9a5/httpie/client.py#L63) as a byte in [update_headers](https://github.com/httpie/httpie/blob/44ae67685d1eb184071899c9e0b7a0dd5d5cb9a5/httpie/uploads.py#L101-L118) using the decode method to generate a string from it.

To solve this issue I added a new test and then modified the `update_headers` function to not decode the header if it is already a string.