### PR TITLE
Fix (#998): Will not expire/delete cookie from session when Set-Cookie only sets Max-Age=0 without Expires

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -38,5 +38,6 @@ Patches and ideas
 * `Edward Yang <https://github.com/honorabrutroll>`_
 * `Aleksandr Vinokurov <https://github.com/aleksandr-vin>`_
 * `Jeff Byrnes <https://github.com/jeffbyrnes>`_
+* `Denis Belavin <https://github.com/LuckyDenis>`_
 
 

--- a/httpie/utils.py
+++ b/httpie/utils.py
@@ -109,6 +109,15 @@ def get_expired_cookies(
         for attrs in attr_sets
     ]
 
+    # HACK/FIXME: https://github.com/psf/requests/issues/5743
+    for cookie in cookies:
+        if 'expires' in cookie:
+            continue
+
+        max_age = cookie.get('max-age')
+        if max_age and max_age.isdigit():
+            cookie['expires'] = now + float(max_age)
+
     return [
         {
             'name': cookie['name'],

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -345,6 +345,15 @@ class TestExpiredCookies(CookieTestBase):
         assert 'cookie1' in updated_session['cookies']
         assert 'cookie2' not in updated_session['cookies']
 
+    def test_get_expired_cookies_using_max_age(self):
+        headers = [
+            ('Set-Cookie', 'one=two; Max-Age=0; path=/; domain=.tumblr.com; HttpOnly')
+        ]
+        expected_expired = [
+            {'name': 'one', 'path': '/'}
+        ]
+        assert get_expired_cookies(headers, now=None) == expected_expired
+
     @pytest.mark.parametrize(
         argnames=['headers', 'now', 'expected_expired'],
         argvalues=[

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -237,7 +237,6 @@ class TestRequestBodyFromFilePath:
             HTTPBIN_WITH_CHUNKED_SUPPORT + '/post',
             '@' + FILE_PATH_ARG,
         )
-        print(r)
         assert HTTP_OK in r
         assert 'Transfer-Encoding: chunked' in r
         assert '"Content-Type": "text/plain"' in r

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -237,6 +237,7 @@ class TestRequestBodyFromFilePath:
             HTTPBIN_WITH_CHUNKED_SUPPORT + '/post',
             '@' + FILE_PATH_ARG,
         )
+        print(r)
         assert HTTP_OK in r
         assert 'Transfer-Encoding: chunked' in r
         assert '"Content-Type": "text/plain"' in r


### PR DESCRIPTION
Summary:
The reason why the `cookie` state information is lost is that when a response is received, the query library does not process `max-age=0`. It was decided to report the problem to the `requests` community and implement a temporary solution.

Done:
- [x] Fix issue #998
- [x] Add test for issue
- [x] Run `make test-all`
- [x] Make https://github.com/psf/requests/issues/5743