### PR TITLE
Correctly handle single-byte Content-Range

### DIFF
--- a/httpie/downloads.py
+++ b/httpie/downloads.py
@@ -81,7 +81,7 @@ def parse_content_range(content_range: str, resumed_from: int) -> int:
     # last-byte-pos value, is invalid. The recipient of an invalid
     # byte-content-range- spec MUST ignore it and any content
     # transferred along with it."
-    if (first_byte_pos >= last_byte_pos
+    if (first_byte_pos > last_byte_pos
         or (instance_length is not None
             and instance_length <= last_byte_pos)):
         raise ContentRangeError(

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -30,6 +30,9 @@ class TestDownloadUtils:
         assert parse('bytes 100-199/200', 100) == 200
         assert parse('bytes 100-199/*', 100) == 200
 
+        # single byte
+        assert parse('bytes 100-100/*', 100) == 101
+
         # missing
         pytest.raises(ContentRangeError, parse, None, 100)
 
@@ -44,9 +47,6 @@ class TestDownloadUtils:
 
         # invalid byte-range-resp-spec
         pytest.raises(ContentRangeError, parse, 'bytes 100-99/199', 100)
-
-        # invalid byte-range-resp-spec
-        pytest.raises(ContentRangeError, parse, 'bytes 100-100/*', 100)
 
     @pytest.mark.parametrize('header, expected_filename', [
         ('attachment; filename=hello-WORLD_123.txt', 'hello-WORLD_123.txt'),


### PR DESCRIPTION
HTTPie fails if it continues a download with a single byte left. For example:
```
$ http -b -d example.org
Downloading 1.23 kB to "index.html"
Done. 1.23 kB in 0.00043s (2.81 MB/s)
$ python3 -c 'import sys; sys.stdout.write(open("index.html").read()[:-1])' > index-short.html
$ http -b -d -c -o index-short.html example.org

http: error: ContentRangeError: Invalid Content-Range returned: 'bytes 1255-1255/1256'
```
The range is inclusive on both ends.