### PR TITLE
Fail gracefully if multiple request data files are supplied

### DIFF
--- a/httpie/cli/argparser.py
+++ b/httpie/cli/argparser.py
@@ -358,13 +358,17 @@ class HTTPieArgumentParser(argparse.ArgumentParser):
 
         if self.args.files and not self.args.form:
             # `http url @/path/to/file`
-            file_fields = list(self.args.files.keys())
-            if file_fields != ['']:
-                self.error(
-                    'Invalid file fields (perhaps you meant --form?): %s'
-                    % ','.join(file_fields))
+            request_file = None
+            for key, file in self.args.files.items():
+                if key != '':
+                    self.error(
+                        'Invalid file fields (perhaps you meant --form?): %s'
+                        % ','.join(self.args.files.keys()))
+                if request_file is not None:
+                    self.error("Can't read request from multiple files")
+                request_file = file
 
-            fn, fd, ct = self.args.files['']
+            fn, fd, ct = request_file
             self.args.files = {}
 
             self._body_from_file(fd)

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -270,3 +270,16 @@ class TestRequestBodyFromFilePath:
         )
         assert r.exit_status == ExitStatus.ERROR
         assert 'cannot be mixed' in r.stderr
+
+    def test_multiple_request_bodies_from_file_by_path(self, httpbin):
+        env = MockEnvironment(stdin_isatty=True)
+        r = http(
+            '--verbose',
+            'POST', httpbin.url + '/post',
+            '@' + FILE_PATH_ARG,
+            '@' + FILE_PATH_ARG,
+            env=env,
+            tolerate_error_exit_status=True,
+        )
+        assert r.exit_status == ExitStatus.ERROR
+        assert 'from multiple files' in r.stderr


### PR DESCRIPTION
HTTPie currently crashes if you give it multiple request data files:
```
$ http : @/dev/null @/dev/null
Traceback (most recent call last):
[...]
    fn, fd, ct = self.args.files['']
ValueError: not enough values to unpack (expected 3, got 2)
```
This replaces that by an error message.