### PR TITLE
Update README.rst: add Linux distrobution openSUSE installation example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,10 @@ system package manager, for example:
 
     # CentOS, RHEL, ...
     $ yum install httpie
+    
+.. code-block:: bash
+    # openSUSE
+    $ zypper in httpie
 
 .. code-block:: bash
 

--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ system package manager, for example:
     
 .. code-block:: bash
     # openSUSE
-    $ zypper in httpie
+    $ zypper install httpie
 
 .. code-block:: bash
 


### PR DESCRIPTION
Add Linux distrobution: openSUSE installation example. It shows how to install `httpie`  by using the system package manager of openSUSE.