### PR TITLE
Replace usage of mock with unittest.mock

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-mock
 pytest
 pytest-cov
 pytest-httpbin>=0.0.6

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ class PyTest(TestCommand):
 tests_require = [
     'pytest-httpbin',
     'pytest',
-    'mock',
 ]
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,5 @@
 """HTTP authentication-related tests."""
-import mock
+from unittest import mock
 import pytest
 
 from httpie.plugins.builtin import HTTPBasicAuth

--- a/tests/test_auth_plugins.py
+++ b/tests/test_auth_plugins.py
@@ -1,4 +1,4 @@
-from mock import mock
+from unittest import mock
 
 from httpie.cli.constants import SEPARATOR_CREDENTIALS
 from httpie.plugins import AuthPlugin

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -1,10 +1,10 @@
 import os
 import tempfile
 import time
+from unittest import mock
 from urllib.request import urlopen
 
 import pytest
-import mock
 from requests.structures import CaseInsensitiveDict
 
 from httpie.downloads import (

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from pytest import raises
 from requests import Request
 from requests.exceptions import ConnectionError

--- a/tests/test_exit_status.py
+++ b/tests/test_exit_status.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from httpie.status import ExitStatus
 from utils import MockEnvironment, http, HTTP_OK

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,7 +1,7 @@
 import argparse
 from pathlib import Path
+from unittest import mock
 
-import mock
 import json
 import os
 import tempfile

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -3,7 +3,7 @@ import json
 import os
 import shutil
 from datetime import datetime
-from mock import mock
+from unittest import mock
 from tempfile import gettempdir
 
 import pytest


### PR DESCRIPTION
Since Python 3, the `mock` dependency is no more required as it is already part of the `unittest` module.

I am not sure it needs a changelog entry, let me know :)