### PR TITLE
Use relative imports

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -39,5 +39,6 @@ Patches and ideas
 * `Aleksandr Vinokurov <https://github.com/aleksandr-vin>`_
 * `Jeff Byrnes <https://github.com/jeffbyrnes>`_
 * `Denis Belavin <https://github.com/LuckyDenis>`_
+* `Mickaël Schoentgen <https://github.com/BoboTiG>`_
 
 

--- a/httpie/__main__.py
+++ b/httpie/__main__.py
@@ -7,7 +7,7 @@ import sys
 
 def main():
     try:
-        from .core import main
+        from httpie.core import main
         exit_status = main()
     except KeyboardInterrupt:
         from httpie.status import ExitStatus

--- a/httpie/cli/argparser.py
+++ b/httpie/cli/argparser.py
@@ -9,23 +9,23 @@ from urllib.parse import urlsplit
 
 from requests.utils import get_netrc_auth
 
-from httpie.cli.argtypes import (
+from .argtypes import (
     AuthCredentials, KeyValueArgType, PARSED_DEFAULT_FORMAT_OPTIONS,
     parse_auth,
     parse_format_options,
 )
-from httpie.cli.constants import (
+from .constants import (
     HTTP_GET, HTTP_POST, OUTPUT_OPTIONS, OUTPUT_OPTIONS_DEFAULT,
     OUTPUT_OPTIONS_DEFAULT_OFFLINE, OUTPUT_OPTIONS_DEFAULT_STDOUT_REDIRECTED,
     OUT_RESP_BODY, PRETTY_MAP, PRETTY_STDOUT_TTY_ONLY, RequestType,
     SEPARATOR_CREDENTIALS,
     SEPARATOR_GROUP_ALL_ITEMS, SEPARATOR_GROUP_DATA_ITEMS, URL_SCHEME_RE,
 )
-from httpie.cli.exceptions import ParseError
-from httpie.cli.requestitems import RequestItems
-from httpie.context import Environment
-from httpie.plugins.registry import plugin_manager
-from httpie.utils import ExplicitNullAuth, get_content_type
+from .exceptions import ParseError
+from .requestitems import RequestItems
+from ..context import Environment
+from ..plugins.registry import plugin_manager
+from ..utils import ExplicitNullAuth, get_content_type
 
 
 class HTTPieHelpFormatter(RawDescriptionHelpFormatter):

--- a/httpie/cli/argtypes.py
+++ b/httpie/cli/argtypes.py
@@ -5,8 +5,8 @@ import sys
 from copy import deepcopy
 from typing import List, Optional, Union
 
-from httpie.cli.constants import DEFAULT_FORMAT_OPTIONS, SEPARATOR_CREDENTIALS
-from httpie.sessions import VALID_SESSION_NAME_PATTERN
+from .constants import DEFAULT_FORMAT_OPTIONS, SEPARATOR_CREDENTIALS
+from ..sessions import VALID_SESSION_NAME_PATTERN
 
 
 class KeyValueArg:

--- a/httpie/cli/definition.py
+++ b/httpie/cli/definition.py
@@ -5,13 +5,13 @@ CLI arguments definition.
 from argparse import (FileType, OPTIONAL, SUPPRESS, ZERO_OR_MORE)
 from textwrap import dedent, wrap
 
-from httpie import __doc__, __version__
-from httpie.cli.argparser import HTTPieArgumentParser
-from httpie.cli.argtypes import (
+from .. import __doc__, __version__
+from .argparser import HTTPieArgumentParser
+from .argtypes import (
     KeyValueArgType, SessionNameValidator,
     readable_file_arg,
 )
-from httpie.cli.constants import (
+from .constants import (
     DEFAULT_FORMAT_OPTIONS, OUTPUT_OPTIONS,
     OUTPUT_OPTIONS_DEFAULT, OUT_REQ_BODY, OUT_REQ_HEAD,
     OUT_RESP_BODY, OUT_RESP_HEAD, PRETTY_MAP, PRETTY_STDOUT_TTY_ONLY,
@@ -19,13 +19,13 @@ from httpie.cli.constants import (
     SORTED_FORMAT_OPTIONS_STRING,
     UNSORTED_FORMAT_OPTIONS_STRING,
 )
-from httpie.output.formatters.colors import (
+from ..output.formatters.colors import (
     AUTO_STYLE, AVAILABLE_STYLES, DEFAULT_STYLE,
 )
-from httpie.plugins.builtin import BuiltinAuthPlugin
-from httpie.plugins.registry import plugin_manager
-from httpie.sessions import DEFAULT_SESSIONS_DIR
-from httpie.ssl import AVAILABLE_SSL_VERSION_ARG_MAPPING, DEFAULT_SSL_CIPHERS
+from ..plugins.builtin import BuiltinAuthPlugin
+from ..plugins.registry import plugin_manager
+from ..sessions import DEFAULT_SESSIONS_DIR
+from ..ssl import AVAILABLE_SSL_VERSION_ARG_MAPPING, DEFAULT_SSL_CIPHERS
 
 
 parser = HTTPieArgumentParser(

--- a/httpie/cli/requestitems.py
+++ b/httpie/cli/requestitems.py
@@ -1,21 +1,21 @@
 import os
 from typing import Callable, Dict, IO, List, Optional, Tuple, Union
 
-from httpie.cli.argtypes import KeyValueArg
-from httpie.cli.constants import (
+from .argtypes import KeyValueArg
+from .constants import (
     SEPARATORS_GROUP_MULTIPART, SEPARATOR_DATA_EMBED_FILE_CONTENTS,
     SEPARATOR_DATA_EMBED_RAW_JSON_FILE,
     SEPARATOR_DATA_RAW_JSON, SEPARATOR_DATA_STRING, SEPARATOR_FILE_UPLOAD,
     SEPARATOR_FILE_UPLOAD_TYPE, SEPARATOR_HEADER, SEPARATOR_HEADER_EMPTY,
     SEPARATOR_QUERY_PARAM,
 )
-from httpie.cli.dicts import (
+from .dicts import (
     MultipartRequestDataDict, RequestDataDict, RequestFilesDict,
     RequestHeadersDict, RequestJSONDataDict,
     RequestQueryParamsDict,
 )
-from httpie.cli.exceptions import ParseError
-from httpie.utils import (get_content_type, load_json_preserve_order)
+from .exceptions import ParseError
+from ..utils import get_content_type, load_json_preserve_order
 
 
 class RequestItems:

--- a/httpie/client.py
+++ b/httpie/client.py
@@ -10,16 +10,16 @@ from urllib.parse import urlparse, urlunparse
 import requests
 # noinspection PyPackageRequirements
 import urllib3
-from httpie import __version__
-from httpie.cli.dicts import RequestHeadersDict
-from httpie.plugins.registry import plugin_manager
-from httpie.sessions import get_httpie_session
-from httpie.ssl import AVAILABLE_SSL_VERSION_ARG_MAPPING, HTTPieHTTPSAdapter
-from httpie.uploads import (
+from . import __version__
+from .cli.dicts import RequestHeadersDict
+from .plugins.registry import plugin_manager
+from .sessions import get_httpie_session
+from .ssl import AVAILABLE_SSL_VERSION_ARG_MAPPING, HTTPieHTTPSAdapter
+from .uploads import (
     compress_request, prepare_request_body,
     get_multipart_data_and_content_type,
 )
-from httpie.utils import get_expired_cookies, repr_dict
+from .utils import get_expired_cookies, repr_dict
 
 
 urllib3.disable_warnings()

--- a/httpie/config.py
+++ b/httpie/config.py
@@ -4,8 +4,8 @@ import os
 from pathlib import Path
 from typing import Union
 
-from httpie import __version__
-from httpie.compat import is_windows
+from . import __version__
+from .compat import is_windows
 
 
 ENV_XDG_CONFIG_HOME = 'XDG_CONFIG_HOME'

--- a/httpie/context.py
+++ b/httpie/context.py
@@ -9,10 +9,10 @@ try:
 except ImportError:
     curses = None  # Compiled w/o curses
 
-from httpie.compat import is_windows
-from httpie.config import DEFAULT_CONFIG_DIR, Config, ConfigFileError
+from .compat import is_windows
+from .config import DEFAULT_CONFIG_DIR, Config, ConfigFileError
 
-from httpie.utils import repr_dict
+from .utils import repr_dict
 
 
 class Environment:

--- a/httpie/core.py
+++ b/httpie/core.py
@@ -8,14 +8,14 @@ import requests
 from pygments import __version__ as pygments_version
 from requests import __version__ as requests_version
 
-from httpie import __version__ as httpie_version
-from httpie.cli.constants import OUT_REQ_BODY, OUT_REQ_HEAD, OUT_RESP_BODY, OUT_RESP_HEAD
-from httpie.client import collect_messages
-from httpie.context import Environment
-from httpie.downloads import Downloader
-from httpie.output.writer import write_message, write_stream, MESSAGE_SEPARATOR_BYTES
-from httpie.plugins.registry import plugin_manager
-from httpie.status import ExitStatus, http_status_to_exit_status
+from . import __version__ as httpie_version
+from .cli.constants import OUT_REQ_BODY, OUT_REQ_HEAD, OUT_RESP_BODY, OUT_RESP_HEAD
+from .client import collect_messages
+from .context import Environment
+from .downloads import Downloader
+from .output.writer import write_message, write_stream, MESSAGE_SEPARATOR_BYTES
+from .plugins.registry import plugin_manager
+from .status import ExitStatus, http_status_to_exit_status
 
 
 # noinspection PyDefaultArgument
@@ -34,7 +34,7 @@ def main(args: List[Union[str, bytes]] = sys.argv, env=Environment()) -> ExitSta
     args = decode_raw_args(args, env.stdin_encoding)
     plugin_manager.load_installed_plugins()
 
-    from httpie.cli.definition import parser
+    from .cli.definition import parser
 
     if env.config.default_options:
         args = env.config.default_options + args

--- a/httpie/downloads.py
+++ b/httpie/downloads.py
@@ -18,9 +18,9 @@ from urllib.parse import urlsplit
 
 import requests
 
-from httpie.models import HTTPResponse
-from httpie.output.streams import RawStream
-from httpie.utils import humanize_bytes
+from .models import HTTPResponse
+from .output.streams import RawStream
+from .utils import humanize_bytes
 
 
 PARTIAL_CONTENT = 206

--- a/httpie/output/formatters/colors.py
+++ b/httpie/output/formatters/colors.py
@@ -15,9 +15,9 @@ from pygments.lexers.special import TextLexer
 from pygments.lexers.text import HttpLexer as PygmentsHttpLexer
 from pygments.util import ClassNotFound
 
-from httpie.compat import is_windows
-from httpie.context import Environment
-from httpie.plugins import FormatterPlugin
+from ...compat import is_windows
+from ...context import Environment
+from ...plugins import FormatterPlugin
 
 
 AUTO_STYLE = 'auto'  # Follows terminal ANSI color styles

--- a/httpie/output/formatters/headers.py
+++ b/httpie/output/formatters/headers.py
@@ -1,4 +1,4 @@
-from httpie.plugins import FormatterPlugin
+from ...plugins import FormatterPlugin
 
 
 class HeadersFormatter(FormatterPlugin):

--- a/httpie/output/formatters/json.py
+++ b/httpie/output/formatters/json.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import json
 
-from httpie.plugins import FormatterPlugin
+from ...plugins import FormatterPlugin
 
 
 class JSONFormatter(FormatterPlugin):

--- a/httpie/output/processing.py
+++ b/httpie/output/processing.py
@@ -1,9 +1,9 @@
 import re
 from typing import Optional, List
 
-from httpie.plugins import ConverterPlugin
-from httpie.plugins.registry import plugin_manager
-from httpie.context import Environment
+from ..plugins import ConverterPlugin
+from ..plugins.registry import plugin_manager
+from ..context import Environment
 
 
 MIME_RE = re.compile(r'^[^/]+/[^/]+$')

--- a/httpie/output/streams.py
+++ b/httpie/output/streams.py
@@ -1,9 +1,9 @@
 from itertools import chain
 from typing import Callable, Iterable, Union
 
-from httpie.context import Environment
-from httpie.models import HTTPMessage
-from httpie.output.processing import Conversion, Formatting
+from ..context import Environment
+from ..models import HTTPMessage
+from .processing import Conversion, Formatting
 
 
 BINARY_SUPPRESSED_NOTICE = (

--- a/httpie/output/writer.py
+++ b/httpie/output/writer.py
@@ -4,10 +4,10 @@ from typing import IO, TextIO, Tuple, Type, Union
 
 import requests
 
-from httpie.context import Environment
-from httpie.models import HTTPRequest, HTTPResponse
-from httpie.output.processing import Conversion, Formatting
-from httpie.output.streams import (
+from ..context import Environment
+from ..models import HTTPRequest, HTTPResponse
+from .processing import Conversion, Formatting
+from .streams import (
     BaseStream, BufferedPrettyStream, EncodedStream, PrettyStream, RawStream,
 )
 

--- a/httpie/plugins/__init__.py
+++ b/httpie/plugins/__init__.py
@@ -3,7 +3,7 @@ WARNING: The plugin API is still work in progress and will
          probably be completely reworked in the future.
 
 """
-from httpie.plugins.base import (
+from .base import (
     AuthPlugin, FormatterPlugin,
     ConverterPlugin, TransportPlugin
 )

--- a/httpie/plugins/builtin.py
+++ b/httpie/plugins/builtin.py
@@ -2,7 +2,7 @@ from base64 import b64encode
 
 import requests.auth
 
-from httpie.plugins.base import AuthPlugin
+from .base import AuthPlugin
 
 
 # noinspection PyAbstractClass

--- a/httpie/plugins/manager.py
+++ b/httpie/plugins/manager.py
@@ -4,8 +4,8 @@ from typing import Dict, List, Type
 
 from pkg_resources import iter_entry_points
 
-from httpie.plugins import AuthPlugin, ConverterPlugin, FormatterPlugin
-from httpie.plugins.base import BasePlugin, TransportPlugin
+from . import AuthPlugin, ConverterPlugin, FormatterPlugin
+from .base import BasePlugin, TransportPlugin
 
 
 ENTRY_POINT_NAMES = [

--- a/httpie/plugins/registry.py
+++ b/httpie/plugins/registry.py
@@ -1,8 +1,8 @@
-from httpie.plugins.manager import PluginManager
-from httpie.plugins.builtin import BasicAuthPlugin, DigestAuthPlugin
-from httpie.output.formatters.headers import HeadersFormatter
-from httpie.output.formatters.json import JSONFormatter
-from httpie.output.formatters.colors import ColorFormatter
+from .manager import PluginManager
+from .builtin import BasicAuthPlugin, DigestAuthPlugin
+from ..output.formatters.headers import HeadersFormatter
+from ..output.formatters.json import JSONFormatter
+from ..output.formatters.colors import ColorFormatter
 
 
 plugin_manager = PluginManager()

--- a/httpie/sessions.py
+++ b/httpie/sessions.py
@@ -13,9 +13,9 @@ from urllib.parse import urlsplit
 from requests.auth import AuthBase
 from requests.cookies import RequestsCookieJar, create_cookie
 
-from httpie.cli.dicts import RequestHeadersDict
-from httpie.config import BaseConfigDict, DEFAULT_CONFIG_DIR
-from httpie.plugins.registry import plugin_manager
+from .cli.dicts import RequestHeadersDict
+from .config import BaseConfigDict, DEFAULT_CONFIG_DIR
+from .plugins.registry import plugin_manager
 
 
 SESSIONS_DIR_NAME = 'sessions'
@@ -141,7 +141,7 @@ class Session(BaseConfigDict):
             }
         else:
             if plugin.auth_parse:
-                from httpie.cli.argtypes import parse_auth
+                from .cli.argtypes import parse_auth
                 parsed = parse_auth(plugin.raw_auth)
                 credentials = {
                     'username': parsed.key,

--- a/httpie/uploads.py
+++ b/httpie/uploads.py
@@ -6,7 +6,7 @@ import requests
 from requests.utils import super_len
 from requests_toolbelt import MultipartEncoder
 
-from httpie.cli.dicts import MultipartRequestDataDict, RequestDataDict
+from .cli.dicts import MultipartRequestDataDict, RequestDataDict
 
 
 class ChunkedUploadStream:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,7 +5,7 @@ import pytest
 from httpie.plugins.builtin import HTTPBasicAuth
 from httpie.status import ExitStatus
 from httpie.utils import ExplicitNullAuth
-from utils import http, add_auth, HTTP_OK, MockEnvironment
+from .utils import http, add_auth, HTTP_OK, MockEnvironment
 import httpie.cli.constants
 import httpie.cli.definition
 

--- a/tests/test_auth_plugins.py
+++ b/tests/test_auth_plugins.py
@@ -3,7 +3,7 @@ from unittest import mock
 from httpie.cli.constants import SEPARATOR_CREDENTIALS
 from httpie.plugins import AuthPlugin
 from httpie.plugins.registry import plugin_manager
-from utils import http, HTTP_OK
+from .utils import http, HTTP_OK
 
 
 # TODO: run all these tests in session mode as well

--- a/tests/test_binary.py
+++ b/tests/test_binary.py
@@ -1,9 +1,9 @@
 """Tests for dealing with binary request and response data."""
 import requests
 
-from fixtures import BIN_FILE_PATH, BIN_FILE_CONTENT, BIN_FILE_PATH_ARG
+from .fixtures import BIN_FILE_PATH, BIN_FILE_CONTENT, BIN_FILE_PATH_ARG
 from httpie.output.streams import BINARY_SUPPRESSED_NOTICE
-from utils import MockEnvironment, http
+from .utils import MockEnvironment, http
 
 
 class TestBinaryRequestData:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ import pytest
 from requests.exceptions import InvalidSchema
 
 import httpie.cli.argparser
-from fixtures import (
+from .fixtures import (
     FILE_CONTENT, FILE_PATH, FILE_PATH_ARG, JSON_FILE_CONTENT,
     JSON_FILE_PATH_ARG,
 )
@@ -15,7 +15,7 @@ from httpie.cli import constants
 from httpie.cli.definition import parser
 from httpie.cli.argtypes import KeyValueArg, KeyValueArgType
 from httpie.cli.requestitems import RequestItems
-from utils import HTTP_OK, MockEnvironment, StdinBytesIO, http
+from .utils import HTTP_OK, MockEnvironment, StdinBytesIO, http
 
 
 class TestItemParsing:

--- a/tests/test_compress.py
+++ b/tests/test_compress.py
@@ -11,9 +11,9 @@ our zlib-encoded request data.
 import base64
 import zlib
 
-from fixtures import FILE_PATH, FILE_CONTENT
+from .fixtures import FILE_PATH, FILE_CONTENT
 from httpie.status import ExitStatus
-from utils import StdinBytesIO, http, HTTP_OK, MockEnvironment
+from .utils import StdinBytesIO, http, HTTP_OK, MockEnvironment
 
 
 def assert_decompressed_equal(base64_compressed_data, expected_str):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,7 @@ from httpie.config import (
     DEFAULT_RELATIVE_XDG_CONFIG_HOME, DEFAULT_WINDOWS_CONFIG_DIR,
     ENV_HTTPIE_CONFIG_DIR, ENV_XDG_CONFIG_HOME, get_default_config_dir,
 )
-from utils import HTTP_OK, MockEnvironment, http
+from .utils import HTTP_OK, MockEnvironment, http
 
 
 def test_default_options(httpbin):

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -5,8 +5,8 @@ Tests for the provided defaults regarding HTTP method, and --json vs. --form.
 from io import BytesIO
 
 from httpie.client import JSON_ACCEPT
-from utils import MockEnvironment, http, HTTP_OK
-from fixtures import FILE_PATH
+from .utils import MockEnvironment, http, HTTP_OK
+from .fixtures import FILE_PATH
 
 
 def test_default_headers_case_insensitive(httpbin):

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from utils import TESTS_ROOT
+from .utils import TESTS_ROOT
 
 
 SOURCE_DIRECTORIES = [

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -11,7 +11,7 @@ from httpie.downloads import (
     parse_content_range, filename_from_content_disposition, filename_from_url,
     get_unique_filename, ContentRangeError, Downloader,
 )
-from utils import http, MockEnvironment
+from .utils import http, MockEnvironment
 
 
 class Response:

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -4,7 +4,7 @@ from requests import Request
 from requests.exceptions import ConnectionError
 
 from httpie.status import ExitStatus
-from utils import HTTP_OK, http
+from .utils import HTTP_OK, http
 
 
 @mock.patch('httpie.core.program')

--- a/tests/test_exit_status.py
+++ b/tests/test_exit_status.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 from httpie.status import ExitStatus
-from utils import MockEnvironment, http, HTTP_OK
+from .utils import MockEnvironment, http, HTTP_OK
 
 
 def test_keyboard_interrupt_during_arg_parsing_exit_status(httpbin):

--- a/tests/test_httpie.py
+++ b/tests/test_httpie.py
@@ -6,11 +6,11 @@ import pytest
 
 import httpie
 import httpie.__main__
-from fixtures import FILE_CONTENT, FILE_PATH
+from .fixtures import FILE_CONTENT, FILE_PATH
 from httpie.cli.exceptions import ParseError
 from httpie.context import Environment
 from httpie.status import ExitStatus
-from utils import HTTP_OK, MockEnvironment, StdinBytesIO, http
+from .utils import HTTP_OK, MockEnvironment, StdinBytesIO, http
 
 
 def test_main_entry_point():

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -1,5 +1,5 @@
-from fixtures import FILE_CONTENT, FILE_PATH_ARG
-from utils import http
+from .fixtures import FILE_CONTENT, FILE_PATH_ARG
+from .utils import http
 
 
 def test_offline():

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -19,7 +19,7 @@ from httpie.cli.argtypes import (
 from httpie.cli.definition import parser
 from httpie.output.formatters.colors import get_lexer
 from httpie.status import ExitStatus
-from utils import COLOR, CRLF, HTTP_OK, MockEnvironment, http
+from .utils import COLOR, CRLF, HTTP_OK, MockEnvironment, http
 
 
 @pytest.mark.parametrize('stdout_isatty', [True, False])

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -2,7 +2,7 @@
 import pytest
 
 from httpie.status import ExitStatus
-from utils import http, HTTP_OK
+from .utils import http, HTTP_OK
 
 
 def test_follow_all_redirects_shown(httpbin):

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -2,8 +2,8 @@
 import pytest
 
 from httpie.compat import is_windows
-from tests.utils.matching import assert_output_matches, Expect
-from utils import HTTP_OK, MockEnvironment, http
+from .utils.matching import assert_output_matches, Expect
+from .utils import HTTP_OK, MockEnvironment, http
 
 
 def test_Host_header_overwrite(httpbin):

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -8,15 +8,14 @@ from tempfile import gettempdir
 
 import pytest
 
-from fixtures import UNICODE
+from .fixtures import FILE_PATH_ARG, UNICODE
 from httpie.plugins import AuthPlugin
 from httpie.plugins.builtin import HTTPBasicAuth
 from httpie.plugins.registry import plugin_manager
 from httpie.sessions import Session
 from httpie.utils import get_expired_cookies
-from tests.test_auth_plugins import basic_auth
-from utils import HTTP_OK, MockEnvironment, http, mk_config_dir
-from fixtures import FILE_PATH_ARG
+from .test_auth_plugins import basic_auth
+from .utils import HTTP_OK, MockEnvironment, http, mk_config_dir
 
 
 class SessionTestBase:

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -6,7 +6,7 @@ import urllib3
 
 from httpie.ssl import AVAILABLE_SSL_VERSION_ARG_MAPPING, DEFAULT_SSL_CIPHERS
 from httpie.status import ExitStatus
-from utils import HTTP_OK, TESTS_ROOT, http
+from .utils import HTTP_OK, TESTS_ROOT, http
 
 
 try:

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -2,8 +2,8 @@ import pytest
 
 from httpie.compat import is_windows
 from httpie.output.streams import BINARY_SUPPRESSED_NOTICE
-from utils import StdinBytesIO, http, MockEnvironment
-from fixtures import BIN_FILE_CONTENT, BIN_FILE_PATH
+from .utils import StdinBytesIO, http, MockEnvironment
+from .fixtures import BIN_FILE_CONTENT, BIN_FILE_PATH
 
 
 # GET because httpbin 500s with binary POST body.

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -9,8 +9,8 @@ TODO: cover more scenarios
  * streamed uploads
 
 """
-from tests.utils.matching import assert_output_matches, Expect
-from utils import http, HTTP_OK, MockEnvironment, HTTPBIN_WITH_CHUNKED_SUPPORT
+from .utils.matching import assert_output_matches, Expect
+from .utils import http, HTTP_OK, MockEnvironment, HTTPBIN_WITH_CHUNKED_SUPPORT
 
 
 RAW_REQUEST = [

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -3,8 +3,8 @@
 Various unicode handling related tests.
 
 """
-from utils import http, HTTP_OK
-from fixtures import UNICODE
+from .utils import http, HTTP_OK
+from .fixtures import UNICODE
 
 
 def test_unicode_headers(httpbin):

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -5,11 +5,11 @@ import pytest
 from httpie.cli.exceptions import ParseError
 from httpie.client import FORM_CONTENT_TYPE
 from httpie.status import ExitStatus
-from utils import (
+from .utils import (
     HTTPBIN_WITH_CHUNKED_SUPPORT, MockEnvironment, StdinBytesIO, http,
     HTTP_OK,
 )
-from fixtures import FILE_PATH_ARG, FILE_PATH, FILE_CONTENT
+from .fixtures import FILE_PATH_ARG, FILE_PATH, FILE_CONTENT
 
 
 def test_chunked_json():

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -4,7 +4,7 @@ import tempfile
 import pytest
 from httpie.context import Environment
 
-from utils import MockEnvironment, http
+from .utils import MockEnvironment, http
 from httpie.compat import is_windows
 
 

--- a/tests/utils/matching/__init__.py
+++ b/tests/utils/matching/__init__.py
@@ -2,7 +2,7 @@ from typing import Iterable
 
 import pytest
 
-from tests.utils.matching.parsing import OutputMatchingError, expect_tokens, Expect
+from .parsing import OutputMatchingError, expect_tokens, Expect
 
 
 __all__ = [

--- a/tests/utils/matching/parsing.py
+++ b/tests/utils/matching/parsing.py
@@ -3,7 +3,7 @@ from typing import Iterable
 from enum import Enum, auto
 
 from httpie.output.writer import MESSAGE_SEPARATOR
-from tests.utils import CRLF
+from ...utils import CRLF
 
 
 class Expect(Enum):

--- a/tests/utils/matching/test_matching.py
+++ b/tests/utils/matching/test_matching.py
@@ -3,8 +3,8 @@ Here we test our output parsing and matching implementation, not HTTPie itself.
 
 """
 from httpie.output.writer import MESSAGE_SEPARATOR
-from tests.utils import CRLF
-from tests.utils.matching import assert_output_does_not_match, assert_output_matches, Expect
+from ...utils import CRLF
+from . import assert_output_does_not_match, assert_output_matches, Expect
 
 
 def test_assert_output_matches_headers_incomplete():


### PR DESCRIPTION
This is a first start, I would like to clean-up the source code to ease future contributions (and why not run a code formatter later, after discussion).

The only place where absolute imports are needed is in `__main__.py` because I know that some code freezers may have issues with that (for the future though).