### PR TITLE
Prefer usage of "python -m pip" instead of "pip"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: 3.9
-      - run: python -m pip install -U pip setuptools wheel
+      - run: python -m pip install --upgrade pip setuptools wheel
       - run: make install
       - run: make pycodestyle
       - run: make test-cover
@@ -29,6 +29,6 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-      - run: python -m pip install -U pip setuptools wheel
-      - run: python -m pip install -U -e .
+      - run: python -m pip install --upgrade pip setuptools wheel
+      - run: python -m pip install --upgrade --editable .
       - run: python setup.py test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: 3.9
-      - run: python -m pip install --upgrade pip setuptools wheel
+      - run: python -m pip install -U pip setuptools wheel
       - run: make install
       - run: make pycodestyle
       - run: make test-cover
@@ -29,6 +29,6 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-      - run: python -m pip install --upgrade pip setuptools wheel
-      - run: python -m pip install --upgrade --editable .
+      - run: python -m pip install -U pip setuptools wheel
+      - run: python -m pip install -U -e .
       - run: python setup.py test

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -172,7 +172,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 * Added fish shell completion (located in ``extras/httpie-completion.fish``
   in the GitHub repo).
 * Updated ``requests`` to 2.10.0 so that SOCKS support can be added via
-  ``pip install requests[socks]``.
+  ``python -m pip install requests[socks]``.
 * Changed the default JSON ``Accept`` header from ``application/json``
   to ``application/json, */*``.
 * Changed the pre-processing of request HTTP headers so that any leading

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -193,7 +193,7 @@ Install HTTPie in editable mode with all the dependencies:
 
 .. code-block:: powershell
 
-    python -m pip install -U -e . -r requirements-dev.txt
+    python -m pip install --upgrade --editable . -r requirements-dev.txt
 
 You should now see ``(httpie)`` next to your shell prompt, and
 the ``http`` command should point to your development copy:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -193,7 +193,7 @@ Install HTTPie in editable mode with all the dependencies:
 
 .. code-block:: powershell
 
-    pip install --upgrade -e . -r requirements-dev.txt
+    python -m pip install -U -e . -r requirements-dev.txt
 
 You should now see ``(httpie)`` next to your shell prompt, and
 the ``http`` command should point to your development copy:

--- a/README.rst
+++ b/README.rst
@@ -135,9 +135,9 @@ and always provides the latest version) is to use `pip`_:
 .. code-block:: bash
 
     # Make sure we have an up-to-date version of pip and setuptools:
-    $ python -m pip install --upgrade pip setuptools
+    $ python -m pip install -U pip setuptools
 
-    $ python -m pip install --upgrade httpie
+    $ python -m pip install -U httpie
 
 
 (If ``pip`` installation fails for some reason, you can try
@@ -175,7 +175,7 @@ Otherwise with ``pip``:
 
 .. code-block:: bash
 
-    $ pip install --upgrade https://github.com/httpie/httpie/archive/master.tar.gz
+    $ python -m pip install -U https://github.com/httpie/httpie/archive/master.tar.gz
 
 
 Verify that now we have the

--- a/README.rst
+++ b/README.rst
@@ -135,9 +135,9 @@ and always provides the latest version) is to use `pip`_:
 .. code-block:: bash
 
     # Make sure we have an up-to-date version of pip and setuptools:
-    $ python -m pip install -U pip setuptools
+    $ python -m pip install --upgrade pip setuptools
 
-    $ python -m pip install -U httpie
+    $ python -m pip install --upgrade httpie
 
 
 (If ``pip`` installation fails for some reason, you can try
@@ -175,7 +175,7 @@ Otherwise with ``pip``:
 
 .. code-block:: bash
 
-    $ python -m pip install -U https://github.com/httpie/httpie/archive/master.tar.gz
+    $ python -m pip install --upgrade https://github.com/httpie/httpie/archive/master.tar.gz
 
 
 Verify that now we have the


### PR DESCRIPTION
It will prevent issues when users think that they are using the correct `pip` version. It can refers to the one from the OS
Python installation, or even worse to a Python 2 installation. Let's be clear on how to install stuff.

~Also used short version of `pip` arguments, because we are all lazy :)~