### PR TITLE
Add --data-raw argument to POST data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -227,6 +227,13 @@ Submitting `forms`_:
     $ http -f POST pie.dev/post hello=World
 
 
+Submitting `forms`_, alternative way:
+
+.. code-block:: bash
+
+    $ http --data-raw 'hello=World' POST pie.dev/post
+
+
 See the request that is being sent using one of the `output options`_:
 
 .. code-block:: bash
@@ -481,8 +488,9 @@ their type is distinguished only by the separator used:
 +------------------------------+---------------------------------------------------+
 | Data Fields                  | Request data fields to be serialized as a JSON    |
 | ``field=value``,             | object (default), to be form-encoded              |
-| ``field=@file.txt``          | (with ``--form, -f``), or to be serialized as     |
-|                              | ``multipart/form-data`` (with ``--multipart``).   |
+| ``field=@file.txt``          | (with ``--form, -f`` or ``--data-raw``), or to    |
+|                              | be serialized as ``multipart/form-data`` (with    |
+|                              | ``--multipart``).                                 |
 +------------------------------+---------------------------------------------------+
 | Raw JSON fields              | Useful when sending JSON and one or               |
 | ``field:=json``,             | more fields need to be a ``Boolean``, ``Number``, |
@@ -673,6 +681,21 @@ Regular forms
     Content-Type: application/x-www-form-urlencoded; charset=utf-8
 
     name=John+Smith
+
+
+Regular forms, alternative way
+------------------------------
+
+.. code-block:: bash
+
+    $ http --data-raw 'name=John Smith' --data-raw 'press=OK' POST pie.dev/post
+
+.. code-block:: http
+
+    POST /post HTTP/1.1
+    Content-Type: application/x-www-form-urlencoded; charset=utf-8
+
+    name=John+Smith&press=OK
 
 
 File upload forms

--- a/httpie/cli/argparser.py
+++ b/httpie/cli/argparser.py
@@ -114,7 +114,6 @@ class HTTPieArgumentParser(argparse.ArgumentParser):
             RequestType.MULTIPART,
         } or bool(self.args.data_raw)
 
-
     def _process_url(self):
         if not URL_SCHEME_RE.match(self.args.url):
             if os.path.basename(self.env.program_name) == 'https':

--- a/httpie/cli/definition.py
+++ b/httpie/cli/definition.py
@@ -16,7 +16,7 @@ from .constants import (
     OUTPUT_OPTIONS_DEFAULT, OUT_REQ_BODY, OUT_REQ_HEAD,
     OUT_RESP_BODY, OUT_RESP_HEAD, PRETTY_MAP, PRETTY_STDOUT_TTY_ONLY,
     RequestType, SEPARATOR_GROUP_ALL_ITEMS, SEPARATOR_PROXY,
-    SORTED_FORMAT_OPTIONS_STRING,
+    SORTED_FORMAT_OPTIONS_STRING, SEPARATOR_DATA_STRING,
     UNSORTED_FORMAT_OPTIONS_STRING,
 )
 from ..output.formatters.colors import (
@@ -182,6 +182,20 @@ content_type.add_argument(
     help='''
     Specify a custom boundary string for multipart/form-data requests.
     Only has effect only together with --form.
+
+    '''
+)
+content_type.add_argument(
+    '--data-raw',
+    action='append',
+    type=KeyValueArgType(SEPARATOR_DATA_STRING),
+    help='''
+    Sends the specified data in a POST request to the HTTP server, in the
+    same way that a browser does when a user has filled in an HTML form
+    and presses the submit button.
+    This will cause HTTPie to pass the data to the server using the
+    content-type application/x-www-form-urlencoded.
+    Compare to -f, --form.
 
     '''
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -236,6 +236,7 @@ class TestArgumentParser:
         self.parser.args.method = None
         self.parser.args.url = 'http://example.com/'
         self.parser.args.request_items = []
+        self.parser.args.data_raw = []
         self.parser.args.ignore_stdin = False
         self.parser.env = MockEnvironment()
         self.parser._guess_method()

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -105,6 +105,11 @@ class TestAutoContentTypeAndAcceptHeaders:
         assert '"Accept": "application/xml"' in r
         assert '"Content-Type": "application/xml"' in r
 
+    def test_POST_data_raw_auto_Content_Type(self, httpbin):
+        r = http('--data-raw', 'user=Alice', 'POST', httpbin.url + '/post')
+        assert HTTP_OK in r
+        assert '"Content-Type": "application/x-www-form-urlencoded' in r
+
     def test_POST_form_auto_Content_Type(self, httpbin):
         r = http('--form', 'POST', httpbin.url + '/post')
         assert HTTP_OK in r

--- a/tests/test_httpie.py
+++ b/tests/test_httpie.py
@@ -89,6 +89,31 @@ def test_POST_JSON_data(httpbin_both):
     assert r.json['json']['foo'] == 'bar'
 
 
+def test_POST_data_raw(httpbin_both):
+    r = http('--data-raw', 'foo=bar', 'POST', httpbin_both + '/post')
+    assert HTTP_OK in r
+    assert '"foo": "bar"' in r
+
+
+def test_POST_data_raw_multiple_calls(httpbin_both):
+    r = http('--data-raw', 'foo=bar', '--data-raw', 'baz=42',
+             'POST', httpbin_both + '/post')
+    assert HTTP_OK in r
+    assert r.json['form'] == {
+        'foo': 'bar',
+        'baz': '42',
+    }
+
+
+def test_POST_data_raw_multiple_values(httpbin_both):
+    r = http('--data-raw', 'foo=bar', '--data-raw', 'foo=42',
+             '--data-raw', 'foo=', 'POST', httpbin_both + '/post')
+    assert HTTP_OK in r
+    assert r.json['form'] == {
+        'foo': ['bar', '42', ''],
+    }
+
+
 def test_POST_form(httpbin_both):
     r = http('--form', 'POST', httpbin_both + '/post', 'foo=bar')
     assert HTTP_OK in r

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -10,6 +10,17 @@ def test_offline():
     assert 'GET /foo' in r
 
 
+def test_offline_data_raw():
+    r = http(
+        '--offline',
+        '--data-raw',
+        'foo=bar',
+        'https://this-should.never-resolve/foo',
+    )
+    assert 'POST /foo' in r
+    assert 'foo=bar' in r
+
+
 def test_offline_form():
     r = http(
         '--offline',

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -141,6 +141,12 @@ class TestVerboseFlag:
         assert HTTP_OK in r
         assert r.count('__test__') == 2
 
+    def test_verbose_data_raw(self, httpbin):
+        r = http('--verbose', '--data-raw', 'A=B', '--data-raw', 'C=D',
+                 'POST', httpbin.url + '/post')
+        assert HTTP_OK in r
+        assert 'A=B&C=D' in r
+
     def test_verbose_form(self, httpbin):
         # https://github.com/httpie/httpie/issues/53
         r = http('--verbose', '--form', 'POST', httpbin.url + '/post',

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -20,6 +20,20 @@ def test_unicode_headers_verbose(httpbin):
     assert UNICODE in r
 
 
+def test_unicode_data_raw_item(httpbin):
+    r = http('--data-raw', u'test=%s' % UNICODE,
+             'POST', httpbin.url + '/post')
+    assert HTTP_OK in r
+    assert r.json['form'] == {'test': UNICODE}
+
+
+def test_unicode_data_raw_item_verbose(httpbin):
+    r = http('--verbose', '--data-raw', u'test=%s' % UNICODE,
+             'POST', httpbin.url + '/post')
+    assert HTTP_OK in r
+    assert UNICODE in r
+
+
 def test_unicode_form_item(httpbin):
     r = http('--form', 'POST', httpbin.url + '/post', u'test=%s' % UNICODE)
     assert HTTP_OK in r


### PR DESCRIPTION
A first draft for `curl --data-raw` support. It would close #534.

Notes:
1. `--data-raw` has been chosen because it is the one from `curl --data-raw` we are emulating here.
2. I wanted to use a short argument version, like `-d`, but it is already used for `--download, -d`. I initially used `-D`, and can restore it if you prefer.
   A possible solution would be to rename `--download, -d` to `--download, -dl`, but it may not be possible due to possible breakings everywhere :)
   I thought we could go with `-D` and then it would be kind of logic to use `--data-binary, -Db` later.
3. No need to implement `curl --data-urlencode 'name=I am Daniel'` as it is implicitely handled.
4. That PR does not handle `curl --data 'birthyear=1905&press=OK'`.
5. That PR does not handle `curl --data-binary ''`.

---

## Single `--data-raw`

Reference:
```shell
$ curl --data 'birthyear=1905' -XPOST pie.dev/post
```
```json
{
  "args": {}, 
  "data": "", 
  "files": {}, 
  "form": {
    "birthyear": "1905"
  }, 
  "headers": {
    "Content-Length": "14", 
    "Content-Type": "application/x-www-form-urlencoded", 
    "User-Agent": "curl/7.64.1"
  }, 
  "json": null, 
  "origin": "...", 
  "url": "http://pie.dev/post"
}
```

New argument `--data-raw`:
```shell
$ http --data-raw 'birthyear=1905' POST pie.dev/post
```
```json
{
    "args": {},
    "data": "",
    "files": {},
    "form": {
        "birthyear": "1905"
    },
    "headers": {
        "Content-Length": "14",
        "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
        "User-Agent": "HTTPie/2.5.0-dev"
    },
    "json": null,
    "origin": "...",
    "url": "http://pie.dev/post"
}
```

## Multiple `--data-raw`

Reference:
```shell
$ curl --data 'birthyear=1905' --data 'press=OK' -XPOST pie.dev/post
```
```json
{
  "args": {}, 
  "data": "", 
  "files": {}, 
  "form": {
    "birthyear": "1905", 
    "press": "OK"
  }, 
  "headers": {
    "Content-Length": "23", 
    "Content-Type": "application/x-www-form-urlencoded", 
    "User-Agent": "curl/7.64.1"
  }, 
  "json": null, 
  "origin": "...", 
  "url": "http://pie.dev/post"
}
```

New argument `--data-raw`:
```shell
$ http --data-raw 'birthyear=1905' --data-raw 'press=OK' POST pie.dev/post
```
```json
    {
        "args": {},
        "data": "",
        "files": {},
        "form": {
            "birthyear": "1905",
            "press": "OK"
        },
        "headers": {
            "Content-Length": "23",
            "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
            "User-Agent": "HTTPie/2.5.0-dev"
        },
        "json": null,
        "origin": "...",
        "url": "http://pie.dev/post"
    }
```
