### PR TITLE
Modernize the code base with f-strings in tests

### DIFF
--- a/tests/test_auth_plugins.py
+++ b/tests/test_auth_plugins.py
@@ -13,7 +13,7 @@ PASSWORD = 'password'
 # Basic auth encoded `USERNAME` and `PASSWORD`
 # noinspection SpellCheckingInspection
 BASIC_AUTH_HEADER_VALUE = 'Basic dXNlcjpwYXNzd29yZA=='
-BASIC_AUTH_URL = '/basic-auth/{0}/{1}'.format(USERNAME, PASSWORD)
+BASIC_AUTH_URL = f'/basic-auth/{USERNAME}/{PASSWORD}'
 AUTH_OK = {'authenticated': True, 'user': USERNAME}
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,7 +36,7 @@ class TestItemParsing:
             self.key_value_arg(r'baz\=bar=foo'),
 
             # files
-            self.key_value_arg(r'bar\@baz@%s' % FILE_PATH_ARG),
+            self.key_value_arg(fr'bar\@baz@{FILE_PATH_ARG}'),
         ])
         # `requests.structures.CaseInsensitiveDict` => `dict`
         headers = dict(items.headers._store.values())
@@ -148,16 +148,16 @@ class TestQuerystring:
         path = '/get?a=1&b=2'
         url = httpbin.url + path
         assert HTTP_OK in r
-        assert 'GET %s HTTP/1.1' % path in r
-        assert '"url": "%s"' % url in r
+        assert f'GET {path} HTTP/1.1' in r
+        assert f'"url": "{url}"' in r
 
     def test_query_string_params_items(self, httpbin):
         r = http('--print=Hhb', 'GET', httpbin.url + '/get', 'a==1')
         path = '/get?a=1'
         url = httpbin.url + path
         assert HTTP_OK in r
-        assert 'GET %s HTTP/1.1' % path in r
-        assert '"url": "%s"' % url in r
+        assert f'GET {path} HTTP/1.1' in r
+        assert f'"url": "{url}"' in r
 
     def test_query_string_params_in_url_and_items_with_duplicates(self,
                                                                   httpbin):
@@ -166,8 +166,8 @@ class TestQuerystring:
         path = '/get?a=1&a=1&a=1&a=1'
         url = httpbin.url + path
         assert HTTP_OK in r
-        assert 'GET %s HTTP/1.1' % path in r
-        assert '"url": "%s"' % url in r
+        assert f'GET {path} HTTP/1.1' in r
+        assert f'"url": "{url}"' in r
 
 
 class TestLocalhostShorthand:
@@ -347,9 +347,9 @@ class TestSchemes:
             http('bah', '--default=scheme=foo+bar-BAZ.123')
 
     def test_default_scheme_option(self, httpbin_secure):
-        url = '{0}:{1}'.format(httpbin_secure.host, httpbin_secure.port)
+        url = f'{httpbin_secure.host}:{httpbin_secure.port}'
         assert HTTP_OK in http(url, '--default-scheme=https')
 
     def test_scheme_when_invoked_as_https(self, httpbin_secure):
-        url = '{0}:{1}'.format(httpbin_secure.host, httpbin_secure.port)
+        url = f'{httpbin_secure.host}:{httpbin_secure.port}'
         assert HTTP_OK in http(url, program_name='https')

--- a/tests/test_httpie.py
+++ b/tests/test_httpie.py
@@ -33,7 +33,7 @@ def test_main_entry_point_keyboard_interrupt(main):
 def test_debug():
     r = http('--debug')
     assert r.exit_status == ExitStatus.SUCCESS
-    assert 'HTTPie %s' % httpie.__version__ in r.stderr
+    assert f'HTTPie {httpie.__version__}' in r.stderr
 
 
 def test_help():

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -261,7 +261,7 @@ class TestLineEndings:
                 break
             assert header.endswith(CRLF), repr(header)
         else:
-            assert 0, 'CRLF between headers and body not found in %r' % msg
+            assert 0, f'CRLF between headers and body not found in {msg!r}'
         body = ''.join(lines)
         assert CRLF not in body
         return body
@@ -269,7 +269,7 @@ class TestLineEndings:
     def test_CRLF_headers_only(self, httpbin):
         r = http('--headers', 'GET', httpbin.url + '/get')
         body = self._validate_crlf(r)
-        assert not body, 'Garbage after headers: %r' % r
+        assert not body, f'Garbage after headers: {r!r}'
 
     def test_CRLF_ugly_response(self, httpbin):
         r = http('--pretty=none', 'GET', httpbin.url + '/get')

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -13,10 +13,10 @@ def test_Host_header_overwrite(httpbin):
     """
     host = 'pie.dev'
     url = httpbin.url + '/get'
-    r = http('--print=hH', url, 'host:{0}'.format(host))
+    r = http('--print=hH', url, f'host:{host}')
     assert HTTP_OK in r
     assert r.lower().count('host:') == 1
-    assert 'host: {0}'.format(host) in r
+    assert f'host: {host}' in r
 
 
 @pytest.mark.skipif(is_windows, reason='Unix-only')

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -182,8 +182,8 @@ class TestSession(SessionTestBase):
     def test_session_unicode(self, httpbin):
         self.start_session(httpbin)
 
-        r1 = http('--session=test', u'--auth=test:' + UNICODE,
-                  'GET', httpbin.url + '/get', u'Test:%s' % UNICODE,
+        r1 = http('--session=test', f'--auth=test:{UNICODE}',
+                  'GET', httpbin.url + '/get', f'Test:{UNICODE}',
                   env=self.env())
         assert HTTP_OK in r1
 
@@ -443,7 +443,7 @@ class TestCookieStorage(CookieTestBase):
             'Cookie:' + new_cookies,
         )
         # Note: cookies in response are in alphabetical order
-        assert 'Cookie: ' + expected in r
+        assert f'Cookie: {expected}' in r
 
         updated_session = json.loads(self.session_path.read_text())
         for name, value in new_cookies_dict.items():

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -53,7 +53,7 @@ def test_ssl_version(httpbin_secure, ssl_version):
             while root.__context__ is not None:
                 root = root.__context__
             if isinstance(root, ssl.SSLError) and root.reason == "TLSV1_ALERT_PROTOCOL_VERSION":
-                pytest.skip("Unsupported TLS version: {}".format(ssl_version))
+                pytest.skip(f'Unsupported TLS version: {ssl_version}')
         else:
             raise
 

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -9,102 +9,102 @@ from .fixtures import UNICODE
 
 def test_unicode_headers(httpbin):
     # httpbin doesn't interpret utf8 headers
-    r = http(httpbin.url + '/headers', u'Test:%s' % UNICODE)
+    r = http(httpbin.url + '/headers', f'Test:{UNICODE}')
     assert HTTP_OK in r
 
 
 def test_unicode_headers_verbose(httpbin):
     # httpbin doesn't interpret utf8 headers
-    r = http('--verbose', httpbin.url + '/headers', u'Test:%s' % UNICODE)
+    r = http('--verbose', httpbin.url + '/headers', f'Test:{UNICODE}')
     assert HTTP_OK in r
     assert UNICODE in r
 
 
 def test_unicode_raw(httpbin):
-    r = http('--raw', u'test %s' % UNICODE, 'POST', httpbin.url + '/post')
+    r = http('--raw', f'test {UNICODE}', 'POST', httpbin.url + '/post')
     assert HTTP_OK in r
-    assert r.json['data'] == u'test %s' % UNICODE
+    assert r.json['data'] == f'test {UNICODE}'
 
 
 def test_unicode_raw_verbose(httpbin):
-    r = http('--verbose', '--raw', u'test %s' % UNICODE,
+    r = http('--verbose', '--raw', f'test {UNICODE}',
              'POST', httpbin.url + '/post')
     assert HTTP_OK in r
     assert UNICODE in r
 
 
 def test_unicode_form_item(httpbin):
-    r = http('--form', 'POST', httpbin.url + '/post', u'test=%s' % UNICODE)
+    r = http('--form', 'POST', httpbin.url + '/post', f'test={UNICODE}')
     assert HTTP_OK in r
     assert r.json['form'] == {'test': UNICODE}
 
 
 def test_unicode_form_item_verbose(httpbin):
     r = http('--verbose', '--form',
-             'POST', httpbin.url + '/post', u'test=%s' % UNICODE)
+             'POST', httpbin.url + '/post', f'test={UNICODE}')
     assert HTTP_OK in r
     assert UNICODE in r
 
 
 def test_unicode_json_item(httpbin):
-    r = http('--json', 'POST', httpbin.url + '/post', u'test=%s' % UNICODE)
+    r = http('--json', 'POST', httpbin.url + '/post', f'test={UNICODE}')
     assert HTTP_OK in r
     assert r.json['json'] == {'test': UNICODE}
 
 
 def test_unicode_json_item_verbose(httpbin):
     r = http('--verbose', '--json',
-             'POST', httpbin.url + '/post', u'test=%s' % UNICODE)
+             'POST', httpbin.url + '/post', f'test={UNICODE}')
     assert HTTP_OK in r
     assert UNICODE in r
 
 
 def test_unicode_raw_json_item(httpbin):
     r = http('--json', 'POST', httpbin.url + '/post',
-             u'test:={ "%s" : [ "%s" ] }' % (UNICODE, UNICODE))
+             f'test:={{ "{UNICODE}" : [ "{UNICODE}" ] }}')
     assert HTTP_OK in r
     assert r.json['json'] == {'test': {UNICODE: [UNICODE]}}
 
 
 def test_unicode_raw_json_item_verbose(httpbin):
     r = http('--json', 'POST', httpbin.url + '/post',
-             u'test:={ "%s" : [ "%s" ] }' % (UNICODE, UNICODE))
+             f'test:={{ "{UNICODE}" : [ "{UNICODE}" ] }}')
     assert HTTP_OK in r
     assert r.json['json'] == {'test': {UNICODE: [UNICODE]}}
 
 
 def test_unicode_url_query_arg_item(httpbin):
-    r = http(httpbin.url + '/get', u'test==%s' % UNICODE)
+    r = http(httpbin.url + '/get', f'test=={UNICODE}')
     assert HTTP_OK in r
     assert r.json['args'] == {'test': UNICODE}, r
 
 
 def test_unicode_url_query_arg_item_verbose(httpbin):
-    r = http('--verbose', httpbin.url + '/get', u'test==%s' % UNICODE)
+    r = http('--verbose', httpbin.url + '/get', f'test=={UNICODE}')
     assert HTTP_OK in r
     assert UNICODE in r
 
 
 def test_unicode_url(httpbin):
-    r = http(httpbin.url + u'/get?test=' + UNICODE)
+    r = http(f'{httpbin.url}/get?test={UNICODE}')
     assert HTTP_OK in r
     assert r.json['args'] == {'test': UNICODE}
 
 # def test_unicode_url_verbose(self):
-#     r = http(httpbin.url + '--verbose', u'/get?test=' + UNICODE)
+#     r = http(httpbin.url + '--verbose', f'/get?test={UNICODE}')
 #     assert HTTP_OK in r
 
 
 def test_unicode_basic_auth(httpbin):
     # it doesn't really authenticate us because httpbin
     # doesn't interpret the utf8-encoded auth
-    http('--verbose', '--auth', u'test:%s' % UNICODE,
-         httpbin.url + u'/basic-auth/test/' + UNICODE)
+    http('--verbose', '--auth', f'test:{UNICODE}',
+         f'{httpbin.url}/basic-auth/test/{UNICODE}')
 
 
 def test_unicode_digest_auth(httpbin):
     # it doesn't really authenticate us because httpbin
     # doesn't interpret the utf8-encoded auth
     http('--auth-type=digest',
-         '--auth', u'test:%s' % UNICODE,
-         httpbin.url + u'/digest-auth/auth/test/' + UNICODE)
+         '--auth', f'test:{UNICODE}',
+         f'{httpbin.url}/digest-auth/auth/test/{UNICODE}')

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -41,7 +41,7 @@ def mk_config_dir() -> Path:
 
 def add_auth(url, auth):
     proto, rest = url.split('://', 1)
-    return proto + '://' + auth + '@' + rest
+    return f'{proto}://{auth}@{rest}'
 
 
 class StdinBytesIO(BytesIO):

--- a/tests/utils/matching/test_matching.py
+++ b/tests/utils/matching/test_matching.py
@@ -15,7 +15,7 @@ def test_assert_output_matches_headers_unterminated():
     assert_output_does_not_match(
         (
             f'HTTP/1.1{CRLF}'
-            f'AAA:BBB'
+            'AAA:BBB'
             f'{CRLF}'
         ),
         [Expect.RESPONSE_HEADERS],
@@ -90,7 +90,7 @@ def test_assert_output_matches_headers_and_body():
             f'HTTP/1.1{CRLF}'
             f'AAA:BBB{CRLF}'
             f'{CRLF}'
-            f'CCC'
+            'CCC'
         ),
         [Expect.RESPONSE_HEADERS, Expect.BODY]
     )
@@ -121,7 +121,7 @@ def test_assert_output_matches_multiple_messages():
             f'EEE:FFF{CRLF}'
             f'{CRLF}'
 
-            f'GGG'
+            'GGG'
             f'{MESSAGE_SEPARATOR}'
         ), [
             Expect.REQUEST_HEADERS,


### PR DESCRIPTION
The code base is now using `f-string` almost everywhere instead of a mix of `str.format()`, `str + str + str` and `'%s...%d' % (arg1, arg2)`.

Simple concatenations were kept for readability purpose.