### PR TITLE
pytest: Add hidden files to norecursedirs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@
 
 [tool:pytest]
 # <https://docs.pytest.org/en/latest/customize.html>
-norecursedirs = tests/fixtures
+norecursedirs = tests/fixtures .*
 addopts = --tb=native --doctest-modules
 
 


### PR DESCRIPTION
The default value already contains this,
but when setting a custom one, it was overridden.

In Fedora, we build the package in `.pyproject-builddir` and not ignoring it confuses pytest:

    _pytest.pathlib.ImportPathMismatchError: ('httpie.__main__', '/builddir/build/BUILD/httpie-2.4.0/.pyproject-builddir/pip-req-build-aedma65c/build/lib/httpie/__main__.py', PosixPath('/builddir/build/BUILD/httpie-2.4.0/.pyproject-builddir/pip-req-build-aedma65c/httpie/__main__.py'))