### PR TITLE
Remove an useless shebang form non-executable file

### DIFF
--- a/httpie/__main__.py
+++ b/httpie/__main__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """The main entry point. Invoke as `http' or `python -m httpie'.
 
 """


### PR DESCRIPTION
Shebangs have no function in non-executable files.
This file does not need to be directly executed.