### PR TITLE
Declare a [test] extra with test dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ if 'bdist_wheel' not in sys.argv:
 
 # bdist_wheel
 extras_require = {
+    'test':  tests_require,
     # https://wheel.readthedocs.io/en/latest/#defining-conditional-dependencies
     ':sys_platform == "win32"': install_requires_win_only,
 }


### PR DESCRIPTION
Since `python setup.py test` is deprecated and `tests_require` is only used by that,
this allows to programmatically read the tests dependencies from the metadata.

This allows us to fetch the test dependencies in Fedora build instead of copy pasting them to a manual declaration.