### PR TITLE
Adapt doctest of tests.utils.http to work on Python 3.10 as well

### DIFF
--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -215,8 +215,8 @@ def http(
         >>> r = http('-a', 'user:pw', httpbin.url + '/basic-auth/user/pw')
         >>> type(r) == StrCLIResponse
         True
-        >>> r.exit_status
-        <ExitStatus.SUCCESS: 0>
+        >>> r.exit_status is ExitStatus.SUCCESS
+        True
         >>> r.stderr
         ''
         >>> 'HTTP/1.1 200 OK' in r


### PR DESCRIPTION
https://docs.python.org/3.10/whatsnew/3.10.html#enum

Python 3.10 changed the repr of enum members, and the doctest of tests.utils.http failed.
Exact reprs are unfortunately not considered stable API between Python releases:

    =================================== FAILURES ===================================
    __________________________ [doctest] tests.utils.http __________________________
    209
    210     Example:
    211
    212     $ http --auth=user:password GET pie.dev/basic-auth/user/password
    213
    214         >>> httpbin = getfixture('httpbin')
    215         >>> r = http('-a', 'user:pw', httpbin.url + '/basic-auth/user/pw')
    216         >>> type(r) == StrCLIResponse
    217         True
    218         >>> r.exit_status
    Expected:
        <ExitStatus.SUCCESS: 0>
    Got:
        ExitStatus.SUCCESS

A simple replacement of the expected output however breaks the doctest on Python 3.9.

This is the best solution I could think of
that keeps the docstring readable and doctest working in Pythons both old and new.


PS I really hope this is the last one for today, sorry for the strom :)