### PR TITLE
Fix --style colors list help indentation

### DIFF
--- a/httpie/cli/definition.py
+++ b/httpie/cli/definition.py
@@ -256,7 +256,7 @@ output_processing.add_argument(
     help='''
     Output coloring style (default is "{default}"). It can be One of:
 
-    {available_styles}
+        {available_styles}
 
     The "{auto_style}" style follows your terminal's ANSI color styles.
 


### PR DESCRIPTION
Before:
```
   --style STYLE, -s STYLE
       Output coloring style(default is "auto"). It can be One of:

        abap, algol, algol_nu, arduino, auto, autumn, borland, bw,           <---- HERE
            colorful, default, emacs, friendly, fruity, gruvbox - dark,
            gruvbox - light, igor, inkpot, lovelace, manni, material,
            monokai, murphy, native, paraiso - dark, paraiso - light,
            pastie, perldoc, rainbow_dash, rrt, sas, solarized,
            solarized - dark, solarized - light, stata, stata - dark, stata-
            light, tango, trac, vim, vs, xcode, zenburn

        The "auto" style follows your terminal's ANSI color styles.

        For non - auto styles to work properly, please make sure that the
        $TERM environment variable is set to "xterm-256color" or similar
        (e.g., via `export TERM=xterm - 256color' in your ~ / .bashrc).
```

After:
```
   --style STYLE, -s STYLE
       Output coloring style(default is "auto"). It can be One of:

            abap, algol, algol_nu, arduino, auto, autumn, borland, bw,       <---- HERE
            colorful, default, emacs, friendly, fruity, gruvbox - dark,
            gruvbox - light, igor, inkpot, lovelace, manni, material,
            monokai, murphy, native, paraiso - dark, paraiso - light,
            pastie, perldoc, rainbow_dash, rrt, sas, solarized,
            solarized - dark, solarized - light, stata, stata - dark, stata-
            light, tango, trac, vim, vs, xcode, zenburn

        The "auto" style follows your terminal's ANSI color styles.

        For non -auto styles to work properly, please make sure that the
        $TERM environment variable is set to "xterm-256color" or similar
        (e.g., via `export TERM=xterm -256color' in your ~/.bashrc).
```
