### PR TITLE
Minor clean-up

### DIFF
--- a/httpie/config.py
+++ b/httpie/config.py
@@ -84,7 +84,7 @@ class BaseConfigDict(dict):
     def load(self):
         config_type = type(self).__name__.lower()
         try:
-            with self.path.open('rt') as f:
+            with self.path.open() as f:
                 try:
                     data = json.load(f)
                 except ValueError as e:

--- a/httpie/plugins/__init__.py
+++ b/httpie/plugins/__init__.py
@@ -7,3 +7,5 @@ from .base import (
     AuthPlugin, FormatterPlugin,
     ConverterPlugin, TransportPlugin
 )
+
+__all__ = ('AuthPlugin', 'ConverterPlugin', 'FormatterPlugin', 'TransportPlugin')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,4 +40,4 @@ def _httpbin_with_chunked_support_available():
 def httpbin_with_chunked_support(_httpbin_with_chunked_support_available):
     if _httpbin_with_chunked_support_available:
         return HTTPBIN_WITH_CHUNKED_SUPPORT
-    pytest.skip('{} not resolvable'.format(HTTPBIN_WITH_CHUNKED_SUPPORT_DOMAIN))
+    pytest.skip(f'{HTTPBIN_WITH_CHUNKED_SUPPORT_DOMAIN} not resolvable')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,8 +25,7 @@ def test_default_options(httpbin):
 def test_config_file_not_valid(httpbin):
     env = MockEnvironment()
     env.create_temp_config_dir()
-    with (env.config_dir / Config.FILENAME).open('w') as f:
-        f.write('{invalid json}')
+    (env.config_dir / Config.FILENAME).write_text('{invalid json}')
     r = http(httpbin + '/get', env=env)
     assert HTTP_OK in r
     assert 'http: warning' in r.stderr

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -3,7 +3,6 @@ import os
 import shutil
 from datetime import datetime
 from unittest import mock
-from tempfile import gettempdir
 
 import pytest
 
@@ -209,11 +208,11 @@ class TestSession(SessionTestBase):
         assert HTTP_OK in r2
         assert r2.json['headers']['User-Agent'] == 'custom'
 
-    def test_download_in_session(self, httpbin):
+    def test_download_in_session(self, tmp_path, httpbin):
         # https://github.com/httpie/httpie/issues/412
         self.start_session(httpbin)
         cwd = os.getcwd()
-        os.chdir(gettempdir())
+        os.chdir(tmp_path)
         try:
             http('--session=test', '--download',
                  httpbin.url + '/get', env=self.env())

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -53,7 +53,8 @@ def test_chunked_stdin(httpbin_with_chunked_support):
 
 
 def test_chunked_stdin_multiple_chunks(httpbin_with_chunked_support):
-    stdin_bytes = FILE_PATH.read_bytes() + b'\n' + FILE_PATH.read_bytes()
+    data = FILE_PATH.read_bytes()
+    stdin_bytes = data + b'\n' + data
     r = http(
         '--verbose',
         '--chunked',

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -19,13 +19,10 @@ class TestWindowsOnly:
 
 
 class TestFakeWindows:
-    def test_output_file_pretty_not_allowed_on_windows(self, httpbin):
+    def test_output_file_pretty_not_allowed_on_windows(self, tmp_path, httpbin):
         env = MockEnvironment(is_windows=True)
-        output_file = os.path.join(
-            tempfile.gettempdir(),
-            self.test_output_file_pretty_not_allowed_on_windows.__name__
-        )
-        r = http('--output', output_file,
+        output_file = tmp_path / 'test_output_file_pretty_not_allowed_on_windows'
+        r = http('--output', str(output_file),
                  '--pretty=all', 'GET', httpbin.url + '/get',
                  env=env, tolerate_error_exit_status=True)
         assert 'Only terminal output can be colorized on Windows' in r.stderr


### PR DESCRIPTION
- Remove default arguments to `open()`.
- Make use of `pytest` mechanisms for temporary folders.