### PR TITLE
Switch from pycodestyle to flake8 for code style checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
           python-version: 3.9
       - run: python -m pip install --upgrade pip setuptools wheel
       - run: make install
-      - run: make pycodestyle
+      - run: make codestyle
       - run: make test-cover
       - run: make codecov-upload
         env:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -123,7 +123,7 @@ Making Changes
 --------------
 
 Please make sure your changes conform to `Style Guide for Python Code`_ (PEP8)
-and that ``make pycodestyle`` passes.
+and that ``make codestyle`` passes.
 
 
 Testing & CI
@@ -152,7 +152,7 @@ HTTPie uses the `pytest`_ runner.
     make test-cover
 
     # Test PEP8 compliance
-    make pycodestyle
+    make codestyle
 
     # Run extended tests — for code as well as .rst files syntax, packaging, etc.
     make test-all

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ test-cover: test
 
 
 # test-all is meant to test everything — even this Makefile
-test-all: clean install test test-dist pycodestyle
+test-all: clean install test test-dist codestyle
 	@echo
 
 
@@ -116,10 +116,15 @@ test-bdist-wheel: clean venv
 twine-check:
 	twine check dist/*
 
-pycodestyle:
-	@echo $(H1)Running pycodestyle$(H1END)
-	@[ -f $(VENV_BIN)/pycodestyle ] || $(VENV_PIP) install pycodestyle
-	$(VENV_BIN)/pycodestyle httpie/ tests/ extras/ *.py
+
+# Kept for convenience, "make codestyle" is preferred though
+pycodestyle: codestyle
+
+
+codestyle:
+	@echo $(H1)Running flake8$(H1END)
+	@[ -f $(VENV_BIN)/flake8 ] || $(VENV_PIP) install --upgrade -r $(REQUIREMENTS)
+	$(VENV_BIN)/flake8 httpie/ tests/ extras/ *.py
 	@echo
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,11 @@
+flake8
+flake8-comprehensions
+flake8-deprecated
+flake8-mutable
+flake8-tuple
 pytest
 pytest-cov
 pytest-httpbin>=0.0.6
 docutils
 wheel
-pycodestyle
 twine

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,17 +11,6 @@ norecursedirs = tests/fixtures .*
 addopts = --tb=native --doctest-modules
 
 
-[pycodestyle]
-# <http://pycodestyle.pycqa.org/en/latest/intro.html#configuration>
-
-exclude = .git,.idea,__pycache__,build,dist,.pytest_cache,*.egg-info
-
-# <http://pycodestyle.pycqa.org/en/latest/intro.html#error-codes>
-# E501 - line too long
-# W503 - line break before binary operator
-ignore = E501,W503
-
-
 [flake8]
 # <https://flake8.pycqa.org/en/latest/user/error-codes.html>
 # E501 - line too long

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -52,7 +52,7 @@ class StdinBytesIO(BytesIO):
 class MockEnvironment(Environment):
     """Environment subclass with reasonable defaults for testing."""
     colors = 0  # For easier debugging
-    stdin_isatty = True,
+    stdin_isatty = True
     stdout_isatty = True
     is_windows = False
 


### PR DESCRIPTION
`flake8` does a little more than just checking PEP8 violations, and I think it is a good balance between `pycodestyle` and other tools like `pylint`. It will catch coding issues as well, but only what maters and without being too noisy for contributors.

WDYT @jakubroztocil? I am open to keep `pycodestyle` or to try something else. Same for the new `make codestyle`, it can be renammed or just kept as-is.