### PR TITLE
Add a Packit configuration for Fedora packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,8 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Packit
+/httpie.spec
+/httpie-*.rpm
+/httpie-*.tar.gz

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,19 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+specfile_path: httpie.spec
+actions:
+  # the current Fedora Rawhide specfile has some patches
+  # so we get it from @hroncok's (= churchyard in Fedora) fork for now
+  # once we have a new release, we'll use: https://src.fedoraproject.org/rpms/httpie/raw/rawhide/f/httpie.spec
+  post-upstream-clone: "wget https://src.fedoraproject.org/fork/churchyard/rpms/httpie/raw/packit/f/httpie.spec -O httpie.spec"
+jobs:
+- job: copr_build
+  trigger: pull_request
+  metadata:
+    targets:
+    - fedora-all
+- job: propose_downstream
+  trigger: release
+  metadata:
+    dist_git_branches:
+    - rawhide

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
     author=httpie.__author__,
     author_email='jakub@roztocil.co',
     license=httpie.__licence__,
-    packages=find_packages(),
+    packages=find_packages(include=['httpie', 'httpie.*']),
     entry_points={
         'console_scripts': [
             'http = httpie.__main__:main',


### PR DESCRIPTION
 - all pull requests are build-tested in https://copr.fedorainfracloud.org
 - new releases will create pull requests in https://src.fedoraproject.org/rpms/httpie

As discussed with @BoboTiG over email. Not tested yet.

The CI build will fail because of https://github.com/httpie/httpie/pull/1057#issuecomment-857684958 -- once that is fixed, I'll rebase this.

The service needs to be enabled first: https://packit.dev/docs/packit-as-a-service/