### PR TITLE
Support requests.response.raw being a file-like object

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
   an alternative to ``stdin``. (`#534`_)
 * Fixed ``--continue --download`` with a single byte to be downloaded left. (`#1032`_)
 * Fixed ``--verbose`` HTTP 307 redirects with streamed request body. (`#1088`_)
+* Fixed support of file-like object responses. (`#1094`_)
 
 
 `2.4.0`_ (2021-02-06)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
   an alternative to ``stdin``. (`#534`_)
 * Fixed ``--continue --download`` with a single byte to be downloaded left. (`#1032`_)
 * Fixed ``--verbose`` HTTP 307 redirects with streamed request body. (`#1088`_)
-* Fixed support of file-like object responses. (`#1094`_)
+* Add internal support for file-like object responses to improve adapter plugin support. (`#1094`_)
 
 
 `2.4.0`_ (2021-02-06)

--- a/httpie/client.py
+++ b/httpie/client.py
@@ -104,10 +104,15 @@ def collect_messages(
                     **send_kwargs,
                 )
 
-            # noinspection PyProtectedMember
-            expired_cookies += get_expired_cookies(
-                headers=response.raw._original_response.msg._headers
-            )
+            if isinstance(response.raw, urllib3.HTTPResponse):
+                # noinspection PyProtectedMember
+                expired_cookies += get_expired_cookies(
+                    headers=response.raw._original_response.msg._headers
+                )
+            else:
+                expired_cookies += get_expired_cookies(
+                    headers=response.headers.items()
+                )
 
             response_count += 1
             if response.next:

--- a/httpie/client.py
+++ b/httpie/client.py
@@ -104,15 +104,9 @@ def collect_messages(
                     **send_kwargs,
                 )
 
-            if isinstance(response.raw, urllib3.HTTPResponse):
-                # noinspection PyProtectedMember
-                expired_cookies += get_expired_cookies(
-                    headers=response.raw._original_response.msg._headers
-                )
-            else:
-                expired_cookies += get_expired_cookies(
-                    headers=response.headers.items()
-                )
+            expired_cookies += get_expired_cookies(
+                response.headers.get('Set-Cookie', '')
+            )
 
             response_count += 1
             if response.next:

--- a/httpie/models.py
+++ b/httpie/models.py
@@ -1,6 +1,8 @@
 from typing import Iterable, Optional
 from urllib.parse import urlsplit
 
+from httpie.utils import split_cookies
+
 
 class HTTPMessage:
     """Abstract class for HTTP messages."""
@@ -68,7 +70,14 @@ class HTTPResponse(HTTPMessage):
         status_line = f'HTTP/{version} {original.status_code} {original.reason}'
         headers = [status_line]
         headers.extend(
-            ': '.join(header) for header in original.headers.items())
+            ': '.join(header)
+            for header in original.headers.items()
+            if header[0] != "Set-Cookie"
+        )
+        headers.extend(
+            f'Set-Cookie: {cookie}'
+            for cookie in split_cookies(original.headers.get('Set-Cookie'))
+        )
         return '\r\n'.join(headers)
 
     @property

--- a/httpie/models.py
+++ b/httpie/models.py
@@ -1,7 +1,7 @@
 from typing import Iterable, Optional
 from urllib.parse import urlsplit
 
-from httpie.utils import split_cookies
+from .utils import split_cookies
 
 
 class HTTPMessage:

--- a/httpie/models.py
+++ b/httpie/models.py
@@ -56,7 +56,7 @@ class HTTPResponse(HTTPMessage):
             raw_version = self._orig.raw._original_response.version
         except AttributeError:
             # Assume HTTP/1.1
-            raw_version = '1.1'
+            raw_version = 11
         version = {
             9: '0.9',
             10: '1.0',

--- a/httpie/models.py
+++ b/httpie/models.py
@@ -72,7 +72,7 @@ class HTTPResponse(HTTPMessage):
         headers.extend(
             ': '.join(header)
             for header in original.headers.items()
-            if header[0] != "Set-Cookie"
+            if header[0] != 'Set-Cookie'
         )
         headers.extend(
             f'Set-Cookie: {cookie}'

--- a/httpie/utils.py
+++ b/httpie/utils.py
@@ -90,8 +90,8 @@ def get_content_type(filename):
 
 def split_cookies(cookies):
     """
-    When Requests stores cookies in ``response.headers['Set-Cookie']``
-    it concatenates all of them through ``, ``
+    When ``requests`` stores cookies in ``response.headers['Set-Cookie']``
+    it concatenates all of them through ``, ``.
 
     This function splits cookies apart being careful to not to
     split on ``, `` which may be part of cookie value.

--- a/httpie/utils.py
+++ b/httpie/utils.py
@@ -5,8 +5,11 @@ from collections import OrderedDict
 from http.cookiejar import parse_ns_headers
 from pprint import pformat
 from typing import List, Optional, Tuple
+import re
 
 import requests.auth
+
+RE_COOKIE_SPLIT = re.compile(r', (?=[^ ;]+=)')
 
 
 def load_json_preserve_order(s):
@@ -86,7 +89,7 @@ def get_content_type(filename):
 
 
 def get_expired_cookies(
-    headers: List[Tuple[str, str]],
+    cookies: str,
     now: float = None
 ) -> List[dict]:
 
@@ -96,9 +99,9 @@ def get_expired_cookies(
         return expires is not None and expires <= now
 
     attr_sets: List[Tuple[str, str]] = parse_ns_headers(
-        value for name, value in headers
-        if name.lower() == 'set-cookie'
+        RE_COOKIE_SPLIT.split(cookies)
     )
+
     cookies = [
         # The first attr name is the cookie name.
         dict(attrs[1:], name=attrs[0][0])

--- a/httpie/utils.py
+++ b/httpie/utils.py
@@ -88,6 +88,19 @@ def get_content_type(filename):
         return content_type
 
 
+def split_cookies(cookies):
+    """
+    When Requests stores cookies in ``response.headers['Set-Cookie']``
+    it concatenates all of them through ``, ``
+
+    This function splits cookies apart being careful to not to
+    split on ``, `` which may be part of cookie value.
+    """
+    if not cookies:
+        return []
+    return RE_COOKIE_SPLIT.split(cookies)
+
+
 def get_expired_cookies(
     cookies: str,
     now: float = None
@@ -99,7 +112,7 @@ def get_expired_cookies(
         return expires is not None and expires <= now
 
     attr_sets: List[Tuple[str, str]] = parse_ns_headers(
-        RE_COOKIE_SPLIT.split(cookies)
+        split_cookies(cookies)
     )
 
     cookies = [

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ dev_require = [
     'pytest-cov',
     'twine',
     'wheel',
+    'flask',
 ]
 install_requires = [
     'requests[socks]>=2.22.0',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ dev_require = [
     'pytest-cov',
     'twine',
     'wheel',
-    'flask',
 ]
 install_requires = [
     'requests[socks]>=2.22.0',

--- a/tests/test_cookie.py
+++ b/tests/test_cookie.py
@@ -1,0 +1,37 @@
+from socket import socket
+from multiprocessing import Process
+
+from flask import Flask, make_response
+
+from .utils import http
+
+app = Flask(__name__)
+
+
+@app.route('/')
+def main():
+    response = make_response()
+    response.set_cookie('hello', value='world')
+    response.set_cookie('oatmeal_raisin', value='is the best')
+    return response
+
+
+def available_port():
+    conn = socket()
+    conn.bind(('', 0))
+    port = conn.getsockname()[1]
+    conn.close()
+    return port
+
+
+def test_cookie_parser():
+    port = available_port()
+    server = Process(target=app.run, kwargs={'port': port})
+    try:
+        server.start()
+        response = http(f'http://localhost:{port}/')
+        assert 'Set-Cookie: hello=world; Path=/' in response
+        assert 'Set-Cookie: oatmeal_raisin="is the best"; Path=/' in response
+    finally:
+        server.terminate()
+        server.join()

--- a/tests/test_cookie.py
+++ b/tests/test_cookie.py
@@ -1,37 +1,47 @@
-from socket import socket
-from multiprocessing import Process
-
-from flask import Flask, make_response
+from http.cookies import SimpleCookie
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Thread
 
 from .utils import http
 
-app = Flask(__name__)
 
+class TestIntegration:
 
-@app.route('/')
-def main():
-    response = make_response()
-    response.set_cookie('hello', value='world')
-    response.set_cookie('oatmeal_raisin', value='is the best')
-    return response
+    def setup_mock_server(self, handler):
+        """Configure mock server."""
+        # Passing 0 as the port will cause a random free port to be chosen.
+        self.mock_server = HTTPServer(('localhost', 0), handler)
+        _, self.mock_server_port = self.mock_server.server_address
 
+        # Start running mock server in a separate thread.
+        # Daemon threads automatically shut down when the main process exits.
+        self.mock_server_thread = Thread(target=self.mock_server.serve_forever)
+        self.mock_server_thread.setDaemon(True)
+        self.mock_server_thread.start()
 
-def available_port():
-    conn = socket()
-    conn.bind(('', 0))
-    port = conn.getsockname()[1]
-    conn.close()
-    return port
+    def test_cookie_parser(self):
+        """Not directly testing HTTPie but `requests` to ensure their cookies handling
+        is still as expected by `get_expired_cookies()`.
+        """
 
+        class MockServerRequestHandler(BaseHTTPRequestHandler):
+            """"HTTP request handler."""
 
-def test_cookie_parser():
-    port = 8080
-    server = Process(target=app.run, kwargs={'port': port})
-    try:
-        server.start()
-        response = http(f'http://localhost:{port}/')
+            def do_GET(self):
+                """Handle GET requests."""
+                # Craft multiple cookies
+                cookie = SimpleCookie()
+                cookie['hello'] = 'world'
+                cookie['hello']['path'] = '/'
+                cookie['oatmeal_raisin'] = 'is the best'
+                cookie['oatmeal_raisin']['path'] = '/'
+
+                # Send HTTP headers
+                self.send_response(200)
+                self.send_header('Set-Cookie', cookie.output())
+                self.end_headers()
+
+        self.setup_mock_server(MockServerRequestHandler)
+        response = http(f'http://localhost:{self.mock_server_port}/')
         assert 'Set-Cookie: hello=world; Path=/' in response
         assert 'Set-Cookie: oatmeal_raisin="is the best"; Path=/' in response
-    finally:
-        server.terminate()
-        server.join()

--- a/tests/test_cookie.py
+++ b/tests/test_cookie.py
@@ -26,7 +26,7 @@ def available_port():
 
 def test_cookie_parser():
     port = available_port()
-    server = Process(target=app.run, kwargs={'port': port})
+    server = Process(target=app.run, kwargs={'port': 8888})
     try:
         server.start()
         response = http(f'http://localhost:{port}/')

--- a/tests/test_cookie.py
+++ b/tests/test_cookie.py
@@ -25,8 +25,8 @@ def available_port():
 
 
 def test_cookie_parser():
-    port = available_port()
-    server = Process(target=app.run, kwargs={'port': 8888})
+    port = 8080
+    server = Process(target=app.run, kwargs={'port': port})
     try:
         server.start()
         response = http(f'http://localhost:{port}/')

--- a/tests/test_cookie.py
+++ b/tests/test_cookie.py
@@ -32,9 +32,9 @@ class TestIntegration:
                 # Craft multiple cookies
                 cookie = SimpleCookie()
                 cookie['hello'] = 'world'
-                cookie['hello']['path'] = '/'
+                cookie['hello']['path'] = self.path
                 cookie['oatmeal_raisin'] = 'is the best'
-                cookie['oatmeal_raisin']['path'] = '/'
+                cookie['oatmeal_raisin']['path'] = self.path
 
                 # Send HTTP headers
                 self.send_response(200)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -343,22 +343,17 @@ class TestExpiredCookies(CookieTestBase):
         assert 'cookie2' not in updated_session['cookies']
 
     def test_get_expired_cookies_using_max_age(self):
-        headers = [
-            ('Set-Cookie', 'one=two; Max-Age=0; path=/; domain=.tumblr.com; HttpOnly')
-        ]
+        cookies = 'one=two; Max-Age=0; path=/; domain=.tumblr.com; HttpOnly'
         expected_expired = [
             {'name': 'one', 'path': '/'}
         ]
-        assert get_expired_cookies(headers, now=None) == expected_expired
+        assert get_expired_cookies(cookies, now=None) == expected_expired
 
     @pytest.mark.parametrize(
-        argnames=['headers', 'now', 'expected_expired'],
+        argnames=['cookies', 'now', 'expected_expired'],
         argvalues=[
             (
-                [
-                    ('Set-Cookie', 'hello=world; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; HttpOnly'),
-                    ('Connection', 'keep-alive')
-                ],
+                'hello=world; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; HttpOnly',
                 None,
                 [
                     {
@@ -368,11 +363,10 @@ class TestExpiredCookies(CookieTestBase):
                 ]
             ),
             (
-                [
-                    ('Set-Cookie', 'hello=world; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; HttpOnly'),
-                    ('Set-Cookie', 'pea=pod; Path=/ab; Expires=Thu, 01-Jan-1970 00:00:00 GMT; HttpOnly'),
-                    ('Connection', 'keep-alive')
-                ],
+                (
+                    'hello=world; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; HttpOnly, '
+                    'pea=pod; Path=/ab; Expires=Thu, 01-Jan-1970 00:00:00 GMT; HttpOnly'
+                ),
                 None,
                 [
                     {'name': 'hello', 'path': '/'},
@@ -382,24 +376,19 @@ class TestExpiredCookies(CookieTestBase):
             (
                 # Checks we gracefully ignore expires date in invalid format.
                 # <https://github.com/httpie/httpie/issues/963>
-                [
-                    ('Set-Cookie', 'pfg=; Expires=Sat, 19-Sep-2020 06:58:14 GMT+0000; Max-Age=0; path=/; domain=.tumblr.com; secure; HttpOnly'),
-                ],
+                'pfg=; Expires=Sat, 19-Sep-2020 06:58:14 GMT+0000; Max-Age=0; path=/; domain=.tumblr.com; secure; HttpOnly',
                 None,
                 []
             ),
             (
-                [
-                    ('Set-Cookie', 'hello=world; Path=/; Expires=Fri, 12 Jun 2020 12:28:55 GMT; HttpOnly'),
-                    ('Connection', 'keep-alive')
-                ],
+                'hello=world; Path=/; Expires=Fri, 12 Jun 2020 12:28:55 GMT; HttpOnly',
                 datetime(2020, 6, 11).timestamp(),
                 []
             ),
         ]
     )
-    def test_get_expired_cookies_manages_multiple_cookie_headers(self, headers, now, expected_expired):
-        assert get_expired_cookies(headers, now=now) == expected_expired
+    def test_get_expired_cookies_manages_multiple_cookie_headers(self, cookies, now, expected_expired):
+        assert get_expired_cookies(cookies, now=now) == expected_expired
 
 
 class TestCookieStorage(CookieTestBase):

--- a/tests/test_transport_plugin.py
+++ b/tests/test_transport_plugin.py
@@ -1,0 +1,45 @@
+from io import BytesIO
+
+from requests.adapters import BaseAdapter
+from requests.models import Response
+from requests.utils import get_encoding_from_headers
+
+from httpie.plugins import TransportPlugin
+from httpie.plugins.registry import plugin_manager
+
+from .utils import HTTP_OK, http
+
+SCHEME = 'http+fake'
+
+
+class FakeAdapter(BaseAdapter):
+    def send(self, request, **kwargs):
+        response = Response()
+        response.status_code = 200
+        response.reason = 'OK'
+        response.headers = {
+            'Content-Type': 'text/html; charset=UTF-8',
+        }
+        response.encoding = get_encoding_from_headers(response.headers)
+        response.raw = BytesIO(b'<!doctype html><html>Hello</html>')
+        return response
+
+
+class FakeTransportPlugin(TransportPlugin):
+    name = 'Fake Transport'
+
+    prefix = SCHEME
+
+    def get_adapter(self):
+        return FakeAdapter()
+
+
+def test_transport_from_requests_response(httpbin):
+    plugin_manager.register(FakeTransportPlugin)
+    try:
+        r = http(f'{SCHEME}://example.com')
+        assert HTTP_OK in r
+        assert 'Hello' in r
+        assert 'Content-Type: text/html; charset=UTF-8' in r
+    finally:
+        plugin_manager.unregister(FakeTransportPlugin)


### PR DESCRIPTION
Previously httpie relied on requests.models.Response.raw being
urllib3.HTTPResponse.  The Requests documentation specifies that
[requests.models.Response.raw](https://docs.python-requests.org/en/master/api/#requests.Response.raw)
is a File-like object but allows for other types for internal use.

This change introduces graceful handling for scenarios when
requests.models.Response.raw is not urllib3.HTTPResponse. In such a scenario
httpie now falls back to extracting metadata from requests.models.Response
directly instead of direct access from protected protected members such as
response.raw._original_response. A side effect in this fallback procedure is
that we can no longer determine HTTP protocol version and report it as `??`.

This change is necessary to make it possible to implement TransportPlugins
without having to also needing to emulate internal behavior of urlib3 and
http.client.

This pull requests is an attempt to address https://github.com/httpie/httpie/issues/1093
