### PR TITLE
Normalize the version

### DIFF
--- a/httpie/__init__.py
+++ b/httpie/__init__.py
@@ -3,6 +3,6 @@ HTTPie: command-line HTTP client for the API era.
 
 """
 
-__version__ = '2.5.0-dev'
+__version__ = '2.5.0.dev0'
 __author__ = 'Jakub Roztocil'
 __licence__ = 'BSD'


### PR DESCRIPTION
To fix that warning:

    setuptools/dist.py:473: UserWarning: Normalizing '2.5.0-dev' to '2.5.0.dev0'

---

It will be useful for the upcoming Snap package. The generated file name will help identifying the version.
Before: `httpie_2.5.0-dev_amd64.snap`
After: `httpie_2.5.0.dev_amd64.snap`