### PR TITLE
Packit: Enable the Koji repsitory in Copr

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,6 +12,8 @@ jobs:
   metadata:
     targets:
     - fedora-all
+    additional_repos:
+    - "https://kojipkgs.fedoraproject.org/repos/f$releasever-build/latest/$basearch/"
 - job: propose_downstream
   trigger: release
   metadata:


### PR DESCRIPTION
By default, only updates that are propagated trough the Fedora's update system
will be available in the community Copr build system.
On stable Fedora releases,
updates (including new packages) might be delayed 1+ week.

This adds the latest Koji (that's the name of the official Fedora build system) repo.
That repo contains more recent packages available during the official Fedora builds.

The Koji repo is not mirrored,
so the Copr builds are more likely to encounter a network issue,
but I think it is worth it.
The `/packit build` command may be used in the pull request if this happens.