### PR TITLE
Rework `__main__.py` to follow best practices

### DIFF
--- a/httpie/__main__.py
+++ b/httpie/__main__.py
@@ -1,7 +1,6 @@
 """The main entry point. Invoke as `http' or `python -m httpie'.
 
 """
-import sys
 
 
 def main():
@@ -12,8 +11,9 @@ def main():
         from httpie.status import ExitStatus
         exit_status = ExitStatus.ERROR_CTRL_C
 
-    sys.exit(exit_status.value)
+    return exit_status.value
 
 
-if __name__ == '__main__':
-    main()
+if __name__ == '__main__':  # pragma: nocover
+    import sys
+    sys.exit(main())

--- a/tests/test_httpie.py
+++ b/tests/test_httpie.py
@@ -17,18 +17,14 @@ from .utils import HTTP_OK, MockEnvironment, StdinBytesIO, http
 def test_main_entry_point():
     # Patch stdin to bypass pytest capture
     with mock.patch.object(Environment, 'stdin', io.StringIO()):
-        with pytest.raises(SystemExit) as e:
-            httpie.__main__.main()
-        assert e.value.code == ExitStatus.ERROR
+        assert httpie.__main__.main() == ExitStatus.ERROR.value
 
 
 @mock.patch('httpie.core.main')
 def test_main_entry_point_keyboard_interrupt(main):
     main.side_effect = KeyboardInterrupt()
     with mock.patch.object(Environment, 'stdin', io.StringIO()):
-        with pytest.raises(SystemExit) as e:
-            httpie.__main__.main()
-        assert e.value.code == ExitStatus.ERROR_CTRL_C
+        assert httpie.__main__.main() == ExitStatus.ERROR_CTRL_C.value
 
 
 def test_debug():


### PR DESCRIPTION
It also simplifies how the `main()` function could be tested.