### PR TITLE
Fix handling of session files with `Cookie:` followed by other headers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
   an alternative to ``stdin``. (`#534`_)
 * Fixed ``--continue --download`` with a single byte to be downloaded left. (`#1032`_)
 * Fixed ``--verbose`` HTTP 307 redirects with streamed request body. (`#1088`_)
+* Fixed session files handling when there are cookies and other headers following. (`#1126`_)
 * Add internal support for file-like object responses to improve adapter plugin support. (`#1094`_)
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
   an alternative to ``stdin``. (`#534`_)
 * Fixed ``--continue --download`` with a single byte to be downloaded left. (`#1032`_)
 * Fixed ``--verbose`` HTTP 307 redirects with streamed request body. (`#1088`_)
-* Fixed session files handling when there are cookies and other headers following. (`#1126`_)
+* Fixed handling of session files with `Cookie:` followed by other headers. (`#1126`_)
 * Add internal support for file-like object responses to improve adapter plugin support. (`#1094`_)
 
 

--- a/httpie/sessions.py
+++ b/httpie/sessions.py
@@ -72,7 +72,7 @@ class Session(BaseConfigDict):
 
         """
         headers = self.headers
-        for name, value in request_headers.items():
+        for name, value in request_headers.copy().items():
 
             if value is None:
                 continue  # Ignore explicitly unset headers

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -179,9 +179,9 @@ class TestSession(SessionTestBase):
         assert r2.json['headers']['Foo'] == 'Bar'
 
     def test_session_with_cookie_followed_by_another_header(self, httpbin):
-        """Non-regression test for issue #1126 where request headers were mutated during iteration:
-
-            RuntimeError: OrderedDict mutated during iteration
+        """
+        Make sure headers don’t get mutated — <https://github.com/httpie/httpie/issues/1126>
+        
         """
         self.start_session(httpbin)
         session_data = {

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -178,6 +178,25 @@ class TestSession(SessionTestBase):
         assert HTTP_OK in r2
         assert r2.json['headers']['Foo'] == 'Bar'
 
+    def test_session_with_cookie_followed_by_another_header(self, httpbin):
+        """Non-regression test for issue #1126 where request headers were mutated during iteration:
+
+            RuntimeError: OrderedDict mutated during iteration
+        """
+        self.start_session(httpbin)
+        session_data = {
+            "headers": {
+                "cookie": "...",
+                "zzz": "..."
+            }
+        }
+        session_path = self.config_dir / 'session-data.json'
+        session_path.write_text(json.dumps(session_data))
+        r = http('--session', str(session_path), 'GET', httpbin.url + '/get',
+                 env=self.env())
+        assert HTTP_OK in r
+        assert 'Zzz' in r
+
     def test_session_unicode(self, httpbin):
         self.start_session(httpbin)
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -181,7 +181,6 @@ class TestSession(SessionTestBase):
     def test_session_with_cookie_followed_by_another_header(self, httpbin):
         """
         Make sure headers don’t get mutated — <https://github.com/httpie/httpie/issues/1126>
-        
         """
         self.start_session(httpbin)
         session_data = {


### PR DESCRIPTION
Fixes #1126.