### PR TITLE
Allow to overwrite the response Content-Type from options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [2.6.0.dev0](https://github.com/httpie/httpie/compare/2.5.0...master) (unreleased)
 
 - Added support for formatting & coloring of JSON bodies preceded by non-JSON data (e.g., an XXSI prefix). ([#1130](https://github.com/httpie/httpie/issues/1130))
+- Added `--format-options response.content_type` to allow overriding the response `Content-Type`. ([#1134](https://github.com/httpie/httpie/issues/1134))
+- Added `--response-content-type` shortcut for setting the response `Content-Type`-related `--format-options`. ([#1134](https://github.com/httpie/httpie/issues/1134))
 - Installed plugins are now listed in `--debug` output. ([#1165](https://github.com/httpie/httpie/issues/1165))
 - Fixed duplicate keys preservation of JSON data. ([#1163](https://github.com/httpie/httpie/issues/1163))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [2.6.0.dev0](https://github.com/httpie/httpie/compare/2.5.0...master) (unreleased)
 
 - Added support for formatting & coloring of JSON bodies preceded by non-JSON data (e.g., an XXSI prefix). ([#1130](https://github.com/httpie/httpie/issues/1130))
-- Added `--format-options response.as` to allow overriding the response `Content-Type`. ([#1134](https://github.com/httpie/httpie/issues/1134))
+- Added `--format-options=response.as:CONTENT_TYPE` to allow overriding the response `Content-Type`. ([#1134](https://github.com/httpie/httpie/issues/1134))
 - Added `--response-as` shortcut for setting the response `Content-Type`-related `--format-options`. ([#1134](https://github.com/httpie/httpie/issues/1134))
 - Installed plugins are now listed in `--debug` output. ([#1165](https://github.com/httpie/httpie/issues/1165))
 - Fixed duplicate keys preservation of JSON data. ([#1163](https://github.com/httpie/httpie/issues/1163))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [2.6.0.dev0](https://github.com/httpie/httpie/compare/2.5.0...master) (unreleased)
 
 - Added support for formatting & coloring of JSON bodies preceded by non-JSON data (e.g., an XXSI prefix). ([#1130](https://github.com/httpie/httpie/issues/1130))
-- Added `--format-options response.content_type` to allow overriding the response `Content-Type`. ([#1134](https://github.com/httpie/httpie/issues/1134))
-- Added `--response-content-type` shortcut for setting the response `Content-Type`-related `--format-options`. ([#1134](https://github.com/httpie/httpie/issues/1134))
+- Added `--format-options response.as` to allow overriding the response `Content-Type`. ([#1134](https://github.com/httpie/httpie/issues/1134))
+- Added `--response-as` shortcut for setting the response `Content-Type`-related `--format-options`. ([#1134](https://github.com/httpie/httpie/issues/1134))
 - Installed plugins are now listed in `--debug` output. ([#1165](https://github.com/httpie/httpie/issues/1165))
 - Fixed duplicate keys preservation of JSON data. ([#1163](https://github.com/httpie/httpie/issues/1163))
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1214,14 +1214,15 @@ You can further control the applied formatting via the more granular [format opt
 The `--format-options=opt1:value,opt2:value` option allows you to control how the output should be formatted
 when formatting is applied. The following options are available:
 
-|           Option | Default value | Shortcuts                |
-| ---------------: | :-----------: | ------------------------ |
-|   `headers.sort` |    `true`     | `--sorted`, `--unsorted` |
-|    `json.format` |    `true`     | N/A                      |
-|    `json.indent` |      `4`      | N/A                      |
-| `json.sort_keys` |    `true`     | `--sorted`, `--unsorted` |
-|     `xml.format` |    `true`     | N/A                      |
-|     `xml.indent` |      `2`      | N/A                      |
+|                  Option | Default value | Shortcuts                                           |
+| ----------------------: | :-----------: | --------------------------------------------------- |
+|          `headers.sort` |    `true`     | `--sorted`, `--unsorted`                            |
+|           `json.format` |    `true`     | N/A                                                 |
+|           `json.indent` |      `4`      | N/A                                                 |
+|        `json.sort_keys` |    `true`     | `--sorted`, `--unsorted`                            |
+| `response.content_type` |     `''`      | [`--response-content-type`](#response-content-type) |
+|            `xml.format` |    `true`     | N/A                                                 |
+|            `xml.indent` |      `2`      | N/A                                                 |
 
 For example, this is how you would disable the default header and JSON key
 sorting, and specify a custom JSON indent size:
@@ -1235,6 +1236,17 @@ sorting-related format options (currently it means JSON keys and headers):
 `--unsorted` and `--sorted`.
 
 This is something you will typically store as one of the default options in your [config](#config) file.
+
+#### Response `Content-Type`
+
+The `--response-content-type` option is a shortcut for `--format-options response.content_type`, and allows you to override the response `Content-Type`.
+It will be effective when the response is pretty-printed, and can be used when the server returns an incorrect `Content-Type` regarding the contents.
+
+For example, the following request will force the response to be treated as XML:
+
+```bash
+$ http --response-content-type 'application/xml' pie.dev/get
+```
 
 ### Binary data
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1239,13 +1239,14 @@ This is something you will typically store as one of the default options in your
 
 #### Response `Content-Type`
 
-The `--response-content-type` option is a shortcut for `--format-options response.content_type`, and allows you to override the response `Content-Type`.
-It will be effective when the response is pretty-printed, and can be used when the server returns an incorrect `Content-Type` regarding the contents.
+The `--response-content-type=value` option is a shortcut for `--format-options response.content_type:value`, 
+and it allows you to override the response `Content-Type` sent by the server. 
+That makes it possible for HTTPie to pretty-print the response even when the server specifies the type incorrectly.
 
 For example, the following request will force the response to be treated as XML:
 
 ```bash
-$ http --response-content-type 'application/xml' pie.dev/get
+$ http --response-content-type=application/xml pie.dev/get
 ```
 
 ### Binary data

--- a/docs/README.md
+++ b/docs/README.md
@@ -1214,15 +1214,15 @@ You can further control the applied formatting via the more granular [format opt
 The `--format-options=opt1:value,opt2:value` option allows you to control how the output should be formatted
 when formatting is applied. The following options are available:
 
-|                  Option | Default value | Shortcuts                                           |
-| ----------------------: | :-----------: | --------------------------------------------------- |
-|          `headers.sort` |    `true`     | `--sorted`, `--unsorted`                            |
-|           `json.format` |    `true`     | N/A                                                 |
-|           `json.indent` |      `4`      | N/A                                                 |
-|        `json.sort_keys` |    `true`     | `--sorted`, `--unsorted`                            |
-| `response.content_type` |     `''`      | [`--response-content-type`](#response-content-type) |
-|            `xml.format` |    `true`     | N/A                                                 |
-|            `xml.indent` |      `2`      | N/A                                                 |
+|           Option | Default value | Shortcuts                                 |
+| ---------------: | :-----------: | ----------------------------------------- |
+|   `headers.sort` |    `true`     | `--sorted`, `--unsorted`                  |
+|    `json.format` |    `true`     | N/A                                       |
+|    `json.indent` |      `4`      | N/A                                       |
+| `json.sort_keys` |    `true`     | `--sorted`, `--unsorted`                  |
+|    `response.as` |     `''`      | [`--response-as`](#response-content-type) |
+|     `xml.format` |    `true`     | N/A                                       |
+|     `xml.indent` |      `2`      | N/A                                       |
 
 For example, this is how you would disable the default header and JSON key
 sorting, and specify a custom JSON indent size:
@@ -1239,14 +1239,14 @@ This is something you will typically store as one of the default options in your
 
 #### Response `Content-Type`
 
-The `--response-content-type=value` option is a shortcut for `--format-options response.content_type:value`, 
-and it allows you to override the response `Content-Type` sent by the server. 
+The `--response-as=value` option is a shortcut for `--format-options response.as:value`,
+and it allows you to override the response `Content-Type` sent by the server.
 That makes it possible for HTTPie to pretty-print the response even when the server specifies the type incorrectly.
 
 For example, the following request will force the response to be treated as XML:
 
 ```bash
-$ http --response-content-type=application/xml pie.dev/get
+$ http --response-as=application/xml pie.dev/get
 ```
 
 ### Binary data

--- a/httpie/cli/argparser.py
+++ b/httpie/cli/argparser.py
@@ -457,7 +457,10 @@ class HTTPieArgumentParser(argparse.ArgumentParser):
             self.error('--continue requires --output to be specified')
 
     def _process_format_options(self):
+        format_options = self.args.format_options or []
+        if self.args.response_content_type is not None:
+            format_options.append('response.content_type:' + self.args.response_content_type)
         parsed_options = PARSED_DEFAULT_FORMAT_OPTIONS
-        for options_group in self.args.format_options or []:
+        for options_group in format_options:
             parsed_options = parse_format_options(options_group, defaults=parsed_options)
         self.args.format_options = parsed_options

--- a/httpie/cli/argparser.py
+++ b/httpie/cli/argparser.py
@@ -458,8 +458,8 @@ class HTTPieArgumentParser(argparse.ArgumentParser):
 
     def _process_format_options(self):
         format_options = self.args.format_options or []
-        if self.args.response_content_type is not None:
-            format_options.append('response.content_type:' + self.args.response_content_type)
+        if self.args.response_as is not None:
+            format_options.append('response.as:' + self.args.response_as)
         parsed_options = PARSED_DEFAULT_FORMAT_OPTIONS
         for options_group in format_options:
             parsed_options = parse_format_options(options_group, defaults=parsed_options)

--- a/httpie/cli/constants.py
+++ b/httpie/cli/constants.py
@@ -91,7 +91,7 @@ DEFAULT_FORMAT_OPTIONS = [
     'json.format:true',
     'json.indent:4',
     'json.sort_keys:true',
-    'response.content_type:' + EMPTY_FORMAT_OPTION,
+    'response.as:' + EMPTY_FORMAT_OPTION,
     'xml.format:true',
     'xml.indent:2',
 ]

--- a/httpie/cli/constants.py
+++ b/httpie/cli/constants.py
@@ -85,11 +85,13 @@ PRETTY_MAP = {
 PRETTY_STDOUT_TTY_ONLY = object()
 
 
+EMPTY_FORMAT_OPTION = "''"
 DEFAULT_FORMAT_OPTIONS = [
     'headers.sort:true',
     'json.format:true',
     'json.indent:4',
     'json.sort_keys:true',
+    'response.content_type:' + EMPTY_FORMAT_OPTION,
     'xml.format:true',
     'xml.indent:2',
 ]

--- a/httpie/cli/definition.py
+++ b/httpie/cli/definition.py
@@ -309,6 +309,18 @@ output_processing.add_argument(
     '''
 )
 
+output_processing.add_argument(
+    '--response-content-type',
+    metavar='CONTENT_TYPE',
+    help='''
+    Override the response Content-Type. It will be effective when the response
+    is pretty-printed, and can be used when the server returns an incorrect
+    Content-Type regarding the contents. It is a shortcut for:
+
+        --format-options=response.content_type:CONTENT_TYPE
+    '''
+)
+
 
 output_processing.add_argument(
     '--format-options',

--- a/httpie/cli/definition.py
+++ b/httpie/cli/definition.py
@@ -310,16 +310,16 @@ output_processing.add_argument(
 )
 
 output_processing.add_argument(
-    '--response-content-type',
+    '--response-as',
     metavar='CONTENT_TYPE',
     help='''
     Override the response Content-Type for formatting purposes, e.g.:
-    
-        --response-content-type=application/xml
-    
+
+        --response-as=application/xml
+
     It is a shortcut for:
 
-        --format-options=response.content_type:CONTENT_TYPE
+        --format-options=response.as:CONTENT_TYPE
     '''
 )
 

--- a/httpie/cli/definition.py
+++ b/httpie/cli/definition.py
@@ -313,9 +313,11 @@ output_processing.add_argument(
     '--response-content-type',
     metavar='CONTENT_TYPE',
     help='''
-    Override the response Content-Type. It will be effective when the response
-    is pretty-printed, and can be used when the server returns an incorrect
-    Content-Type regarding the contents. It is a shortcut for:
+    Override the response Content-Type for formatting purposes, e.g.:
+    
+        --response-content-type=application/xml
+    
+    It is a shortcut for:
 
         --format-options=response.content_type:CONTENT_TYPE
     '''

--- a/httpie/output/processing.py
+++ b/httpie/output/processing.py
@@ -33,6 +33,7 @@ class Formatting:
         :param kwargs: additional keyword arguments for processors
 
         """
+        self.options = kwargs['format_options']
         available_plugins = plugin_manager.get_formatters_grouped()
         self.enabled_plugins = []
         for group in groups:

--- a/httpie/output/streams.py
+++ b/httpie/output/streams.py
@@ -142,7 +142,7 @@ class PrettyStream(EncodedStream):
     def get_mime(self) -> str:
         mime = parse_header_content_type(self.msg.content_type)[0]
         if isinstance(self.msg, HTTPResponse):
-            forced_content_type = self.formatting.options['response']['content_type']
+            forced_content_type = self.formatting.options['response']['as']
             if forced_content_type != EMPTY_FORMAT_OPTION:
                 mime = parse_header_content_type(forced_content_type)[0] or mime
         return mime

--- a/httpie/output/streams.py
+++ b/httpie/output/streams.py
@@ -2,11 +2,12 @@ from abc import ABCMeta, abstractmethod
 from itertools import chain
 from typing import Callable, Iterable, Union
 
+from ..cli.constants import EMPTY_FORMAT_OPTION
 from ..context import Environment
 from ..constants import UTF8
-from ..models import HTTPMessage
+from ..models import HTTPMessage, HTTPResponse
 from .processing import Conversion, Formatting
-
+from .utils import parse_header_content_type
 
 BINARY_SUPPRESSED_NOTICE = (
     b'\n'
@@ -136,7 +137,15 @@ class PrettyStream(EncodedStream):
         super().__init__(**kwargs)
         self.formatting = formatting
         self.conversion = conversion
-        self.mime = self.msg.content_type.split(';')[0]
+        self.mime = self.get_mime()
+
+    def get_mime(self) -> str:
+        mime = parse_header_content_type(self.msg.content_type)[0]
+        if isinstance(self.msg, HTTPResponse):
+            forced_content_type = self.formatting.options['response']['content_type']
+            if forced_content_type != EMPTY_FORMAT_OPTION:
+                mime = parse_header_content_type(forced_content_type)[0] or mime
+        return mime
 
     def get_headers(self) -> bytes:
         return self.formatting.format_headers(

--- a/httpie/output/utils.py
+++ b/httpie/output/utils.py
@@ -35,3 +35,57 @@ def parse_prefixed_json(data: str) -> Tuple[str, str]:
     data_prefix = matches[0] if matches else ''
     body = data[len(data_prefix):]
     return data_prefix, body
+
+
+def parse_header_content_type(line):
+    """Parse a Content-Type like header.
+    Return the main Content-Type and a dictionary of options.
+        >>> parse_header_content_type('application/xml; charset=utf-8')
+        ('application/xml', {'charset': 'utf-8'})
+        >>> parse_header_content_type('application/xml; charset = utf-8')
+        ('application/xml', {'charset': 'utf-8'})
+        >>> parse_header_content_type('application/html+xml;ChArSeT="UTF-8"')
+        ('application/html+xml', {'charset': 'UTF-8'})
+        >>> parse_header_content_type('application/xml')
+        ('application/xml', {})
+        >>> parse_header_content_type(';charset=utf-8')
+        ('', {'charset': 'utf-8'})
+        >>> parse_header_content_type('charset=utf-8')
+        ('', {'charset': 'utf-8'})
+        >>> parse_header_content_type('multipart/mixed; boundary="gc0pJq0M:08jU534c0p"')
+        ('multipart/mixed', {'boundary': 'gc0pJq0M:08jU534c0p'})
+        >>> parse_header_content_type('Message/Partial; number=3; total=3; id="oc=jpbe0M2Yt4s@foo.com"')
+        ('Message/Partial', {'number': '3', 'total': '3', 'id': 'oc=jpbe0M2Yt4s@foo.com'})
+    """
+    # Source: https://github.com/python/cpython/blob/bb3e0c2/Lib/cgi.py#L230
+
+    def _parseparam(s: str):
+        # Source: https://github.com/python/cpython/blob/bb3e0c2/Lib/cgi.py#L218
+        while s[:1] == ';':
+            s = s[1:]
+            end = s.find(';')
+            while end > 0 and (s.count('"', 0, end) - s.count('\\"', 0, end)) % 2:
+                end = s.find(';', end + 1)
+            if end < 0:
+                end = len(s)
+            f = s[:end]
+            yield f.strip()
+            s = s[end:]
+
+    # Special case: 'key=value' only (without starting with ';').
+    if ';' not in line and '=' in line:
+        line = ';' + line
+
+    parts = _parseparam(';' + line)
+    key = parts.__next__()
+    pdict = {}
+    for p in parts:
+        i = p.find('=')
+        if i >= 0:
+            name = p[:i].strip().lower()
+            value = p[i + 1:].strip()
+            if len(value) >= 2 and value[0] == value[-1] == '"':
+                value = value[1:-1]
+                value = value.replace('\\\\', '\\').replace('\\"', '"')
+            pdict[name] = value
+    return key, pdict

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -377,6 +377,9 @@ class TestFormatOptions:
                         'indent': 10,
                         'format': True
                     },
+                    'response': {
+                        'content_type': "''",
+                    },
                     'xml': {
                         'format': True,
                         'indent': 2,
@@ -396,6 +399,9 @@ class TestFormatOptions:
                         'indent': 4,
                         'format': True
                     },
+                    'response': {
+                        'content_type': "''",
+                    },
                     'xml': {
                         'format': True,
                         'indent': 2,
@@ -417,6 +423,9 @@ class TestFormatOptions:
                         'indent': 4,
                         'format': True
                     },
+                    'response': {
+                        'content_type': "''",
+                    },
                     'xml': {
                         'format': True,
                         'indent': 2,
@@ -435,6 +444,7 @@ class TestFormatOptions:
             (
                 [
                     '--format-options=json.indent:2',
+                    '--format-options=response.content_type:application/xml; charset=utf-8',
                     '--format-options=xml.format:false',
                     '--format-options=xml.indent:4',
                     '--unsorted',
@@ -448,6 +458,9 @@ class TestFormatOptions:
                         'sort_keys': True,
                         'indent': 2,
                         'format': True
+                    },
+                    'response': {
+                        'content_type': 'application/xml; charset=utf-8',
                     },
                     'xml': {
                         'format': False,
@@ -470,6 +483,9 @@ class TestFormatOptions:
                         'indent': 2,
                         'format': True
                     },
+                    'response': {
+                        'content_type': "''",
+                    },
                     'xml': {
                         'format': True,
                         'indent': 2,
@@ -491,6 +507,9 @@ class TestFormatOptions:
                         'sort_keys': True,
                         'indent': 2,
                         'format': True
+                    },
+                    'response': {
+                        'content_type': "''",
                     },
                     'xml': {
                         'format': True,

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -378,7 +378,7 @@ class TestFormatOptions:
                         'format': True
                     },
                     'response': {
-                        'content_type': "''",
+                        'as': "''",
                     },
                     'xml': {
                         'format': True,
@@ -400,7 +400,7 @@ class TestFormatOptions:
                         'format': True
                     },
                     'response': {
-                        'content_type': "''",
+                        'as': "''",
                     },
                     'xml': {
                         'format': True,
@@ -424,7 +424,7 @@ class TestFormatOptions:
                         'format': True
                     },
                     'response': {
-                        'content_type': "''",
+                        'as': "''",
                     },
                     'xml': {
                         'format': True,
@@ -444,7 +444,7 @@ class TestFormatOptions:
             (
                 [
                     '--format-options=json.indent:2',
-                    '--format-options=response.content_type:application/xml; charset=utf-8',
+                    '--format-options=response.as:application/xml; charset=utf-8',
                     '--format-options=xml.format:false',
                     '--format-options=xml.indent:4',
                     '--unsorted',
@@ -460,7 +460,7 @@ class TestFormatOptions:
                         'format': True
                     },
                     'response': {
-                        'content_type': 'application/xml; charset=utf-8',
+                        'as': 'application/xml; charset=utf-8',
                     },
                     'xml': {
                         'format': False,
@@ -484,7 +484,7 @@ class TestFormatOptions:
                         'format': True
                     },
                     'response': {
-                        'content_type': "''",
+                        'as': "''",
                     },
                     'xml': {
                         'format': True,
@@ -509,7 +509,7 @@ class TestFormatOptions:
                         'format': True
                     },
                     'response': {
-                        'content_type': "''",
+                        'as': "''",
                     },
                     'xml': {
                         'format': True,

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -88,12 +88,12 @@ def test_invalid_xml(file):
 
 @responses.activate
 def test_content_type_from_format_options_argument():
-    """Test server XML with a incorrect Content-Type header.
+    """Test XML response with a incorrect Content-Type header.
     Using the --format-options to force the good one.
     """
     responses.add(responses.GET, URL_EXAMPLE, body=XML_DATA_RAW,
                   content_type='plain/text')
-    args = ('--format-options', 'response.content_type:application/xml',
+    args = ('--format-options', 'response.as:application/xml',
             URL_EXAMPLE)
 
     # Ensure the option is taken into account only for responses.
@@ -108,13 +108,12 @@ def test_content_type_from_format_options_argument():
 
 @responses.activate
 def test_content_type_from_shortcut_argument():
-    """Test server XML with a incorrect Content-Type header.
+    """Test XML response with a incorrect Content-Type header.
     Using the --format-options shortcut to force the good one.
     """
     responses.add(responses.GET, URL_EXAMPLE, body=XML_DATA_RAW,
                   content_type='text/plain')
-    args = ('--response-content-type', 'application/xml',
-            URL_EXAMPLE)
+    args = ('--response-as', 'application/xml', URL_EXAMPLE)
 
     # Ensure the option is taken into account only for responses.
     # Request
@@ -128,12 +127,12 @@ def test_content_type_from_shortcut_argument():
 
 @responses.activate
 def test_content_type_from_incomplete_format_options_argument():
-    """Test server XML with a incorrect Content-Type header.
+    """Test XML response with a incorrect Content-Type header.
     Using the --format-options to use a partial Content-Type without mime type.
     """
     responses.add(responses.GET, URL_EXAMPLE, body=XML_DATA_RAW,
                   content_type='text/plain')
 
     # The provided Content-Type is simply ignored, and so no formatting is done.
-    r = http('--response-content-type', 'charset=utf-8', URL_EXAMPLE)
+    r = http('--response-as', 'charset=utf-8', URL_EXAMPLE)
     assert XML_DATA_RAW in r


### PR DESCRIPTION
It implements the support for custom mime types.
It is a start, it will be used later in  #1110 to support custom a charset.

Summary:
```bash
$ http --response-as 'appllication/xml' \
    https://raw.githubusercontent.com/httpie/httpie/master/tests/fixtures/xmldata/valid/simple_raw.xml
```