### PR TITLE
use LZO compression for snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -45,6 +45,7 @@ adopt-info: httpie
 base: core20
 confinement: strict
 grade: stable
+compression: lzo
 
 parts:
   httpie:


### PR DESCRIPTION
The snap archive should be compressed using LZO compression. This makes things relatively fast. 

Some reading on why https://snapcraft.io/blog/why-lzo-was-chosen-as-the-new-compression-method