### PR TITLE
[snap] Remove personal-files interface

### DIFF
--- a/.github/workflows/packaging-linux-snap.yml
+++ b/.github/workflows/packaging-linux-snap.yml
@@ -1,0 +1,25 @@
+name: Linux snap
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/packaging-linux-snap.yml
+      - snapcraft.yaml
+
+jobs:
+  snap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        uses: snapcore/action-build@v1
+        id: snapcraft
+      - name: Install
+        run: sudo snap install --dangerous ${{ steps.snapcraft.outputs.snap }}
+      - name: Test
+        run: |
+          httpie.http --version
+          httpie.https --version
+          # Auto-aliases cannot be tested when installing a snap outside the store.
+          # http --version
+          # https --version

--- a/.github/workflows/packaging-mac-brew.yml
+++ b/.github/workflows/packaging-mac-brew.yml
@@ -1,19 +1,19 @@
-name: Check Brew Formula
+name: Mac brew
 
 on:
   pull_request:
     paths:
-      - .github/workflows/packaging-mac-check-formula.yml
+      - .github/workflows/packaging-mac-brew.yml
       - extras/httpie.rb
 
 jobs:
-  check-formula:
+  brew:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Brew
+      - name: Setup brew
         run: |
           brew developer on
           brew update
-      - name: Build and test the Formula
+      - name: Build and test the formula
         run: make brew-test

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -93,7 +93,7 @@ apps:
   http:
     command: bin/http
     plugs: &plugs
-      - dot-config-httpie
+    # - dot-config-httpie
       - home
       - network
       - removable-media


### PR DESCRIPTION
Use of the `personal-files` interface is reserved for vetted publishers.

The interface requires a validation, but we need to publish at least one package first. So let's skip that part, release a version and ask for the interface access in a second time.

Also add a workflow to build & test the snap package.