### PR TITLE
Include plugin info in `--debug` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - Fixed duplicate keys preservation of JSON data. ([#1163](https://github.com/httpie/httpie/issues/1163))
 - Added support for formatting & coloring of JSON bodies preceded by non-JSON data (e.g., an XXSI prefix). ([#1130](https://github.com/httpie/httpie/issues/1130))
+- Installed plugins are now listed in `--debug` output. ([#1130](https://github.com/httpie/httpie/issues/1130))
 
 ## [2.5.0](https://github.com/httpie/httpie/compare/2.4.0...2.5.0) (2021-09-06)
 

--- a/httpie/core.py
+++ b/httpie/core.py
@@ -227,6 +227,8 @@ def print_debug_info(env: Environment):
     ])
     env.stderr.write('\n\n')
     env.stderr.write(repr(env))
+    env.stderr.write('\n\n')
+    env.stderr.write(repr(plugin_manager))
     env.stderr.write('\n')
 
 

--- a/httpie/plugins/manager.py
+++ b/httpie/plugins/manager.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Type
 
 from pkg_resources import iter_entry_points
 
+from ..utils import repr_dict
 from . import AuthPlugin, ConverterPlugin, FormatterPlugin
 from .base import BasePlugin, TransportPlugin
 
@@ -65,5 +66,13 @@ class PluginManager(list):
     def get_transport_plugins(self) -> List[Type[TransportPlugin]]:
         return self.filter(TransportPlugin)
 
+    def __str__(self):
+        return repr_dict({
+            'adapters': self.get_transport_plugins(),
+            'auth': self.get_auth_plugins(),
+            'converters': self.get_converters(),
+            'formatters': self.get_formatters(),
+        })
+
     def __repr__(self):
-        return f'<PluginManager: {list(self)}>'
+        return f'<{type(self).__name__} {self}>'


### PR DESCRIPTION
Closes #455.

Example:

```bash
$ http --debug pie.dev/get
HTTPie 2.6.0.dev0
Requests 2.26.0
Pygments 2.10.0
Python 3.9.7+ (heads/3.9:09390c837a, Sep 22 2021, 11:36:19) 
[GCC 10.3.0]
/home/tiger-222/projects/httpie/venv39/bin/python
Linux 5.10.0-8-amd64

<Environment {'colors': 256,
 'config': {'default_options': ['--style=monokai']},
 'config_dir': PosixPath('/home/tiger-222/.httpie'),
 'devnull': <property object at 0x7f1b74dbb130>,
 'is_windows': False,
 'log_error': <function Environment.log_error at 0x7f1b74da9d30>,
 'program_name': '__main__.py',
 'stderr': <_io.TextIOWrapper name='<stderr>' mode='w' encoding='utf-8'>,
 'stderr_isatty': True,
 'stdin': <_io.TextIOWrapper name='<stdin>' mode='r' encoding='utf-8'>,
 'stdin_encoding': 'utf-8',
 'stdin_isatty': True,
 'stdout': <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>,
 'stdout_encoding': 'utf-8',
 'stdout_isatty': True}>

<PluginManager {'adapters': [<class 'httpie_snapdsocket.SnapdSocketTransportPlugin'>],
 'auth': [<class 'httpie.plugins.builtin.BasicAuthPlugin'>,
          <class 'httpie.plugins.builtin.DigestAuthPlugin'>],
 'converters': [],
 'formatters': [<class 'httpie.output.formatters.headers.HeadersFormatter'>,
                <class 'httpie.output.formatters.json.JSONFormatter'>,
                <class 'httpie.output.formatters.xml.XMLFormatter'>,
                <class 'httpie.output.formatters.colors.ColorFormatter'>]}>

>>> requests.request(**{'auth': None,
 'data': RequestJSONDataDict(),
 'headers': {'User-Agent': b'HTTPie/2.6.0.dev0'},
 'method': 'get',
 'params': <generator object MultiValueOrderedDict.items at 0x7f1b742d7510>,
 'url': 'http://pie.dev/get'})

HTTP/1.1 200 OK
CF-Cache-Status: DYNAMIC
CF-RAY: 69347a9b088fedbf-CDG
Connection: keep-alive
Content-Encoding: gzip
Content-Type: application/json
Date: Thu, 23 Sep 2021 14:31:50 GMT
NEL: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
Report-To: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=Pi%2Bew9tk41cRrv9swQiYxozWzBIwPtMk8%2F0ZpzyYLO%2B1PEhq8%2Fk%2BqO8heSXy5JBRXsdpx%2Bw0e1RskVMsoQztEdvWywJzn0JfU4Ct2sHm6VZ2AkPN9G0pZPg7"}],"group":"cf-nel","max_age":604800}
Server: cloudflare
Transfer-Encoding: chunked
access-control-allow-credentials: true
access-control-allow-origin: *
alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400, h3-28=":443"; ma=86400, h3-27=":443"; ma=86400

{
    "args": {},
    "headers": {
        "Accept": "*/*",
        "Accept-Encoding": "gzip",
        "Cdn-Loop": "cloudflare",
        "Cf-Connecting-Ip": "89.159.87.157",
        "Cf-Ipcountry": "FR",
        "Cf-Ray": "69347a9b088fedbf-FRA",
        "Cf-Visitor": "{\"scheme\":\"http\"}",
        "Connection": "Keep-Alive",
        "Host": "pie.dev",
        "User-Agent": "HTTPie/2.6.0.dev0"
    },
    "origin": "89.159.87.157",
    "url": "http://pie.dev/get"
}
```