### PR TITLE
Fix encoding error with non-prettified encoded responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Added support for formatting & coloring of JSON bodies preceded by non-JSON data (e.g., an XXSI prefix). ([#1130](https://github.com/httpie/httpie/issues/1130))
 - Added `--format-options=response.as:CONTENT_TYPE` to allow overriding the response `Content-Type`. ([#1134](https://github.com/httpie/httpie/issues/1134))
 - Added `--response-as` shortcut for setting the response `Content-Type`-related `--format-options`. ([#1134](https://github.com/httpie/httpie/issues/1134))
-- Improved handling of prettified responses without correct `Content-Type` encoding. ([#1110](https://github.com/httpie/httpie/issues/1110))
+- Improved handling of responses without correct `Content-Type` encoding. ([#1110](https://github.com/httpie/httpie/issues/1110), [#1168](https://github.com/httpie/httpie/issues/1168))
 - Installed plugins are now listed in `--debug` output. ([#1165](https://github.com/httpie/httpie/issues/1165))
 - Fixed duplicate keys preservation of JSON data. ([#1163](https://github.com/httpie/httpie/issues/1163))
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1214,15 +1214,14 @@ You can further control the applied formatting via the more granular [format opt
 The `--format-options=opt1:value,opt2:value` option allows you to control how the output should be formatted
 when formatting is applied. The following options are available:
 
-|           Option | Default value | Shortcuts                                 |
-| ---------------: | :-----------: | ----------------------------------------- |
-|   `headers.sort` |    `true`     | `--sorted`, `--unsorted`                  |
-|    `json.format` |    `true`     | N/A                                       |
-|    `json.indent` |      `4`      | N/A                                       |
-| `json.sort_keys` |    `true`     | `--sorted`, `--unsorted`                  |
-|    `response.as` |     `''`      | [`--response-as`](#response-content-type) |
-|     `xml.format` |    `true`     | N/A                                       |
-|     `xml.indent` |      `2`      | N/A                                       |
+|           Option | Default value | Shortcuts                |
+| ---------------: | :-----------: | ------------------------ |
+|   `headers.sort` |    `true`     | `--sorted`, `--unsorted` |
+|    `json.format` |    `true`     | N/A                      |
+|    `json.indent` |      `4`      | N/A                      |
+| `json.sort_keys` |    `true`     | `--sorted`, `--unsorted` |
+|     `xml.format` |    `true`     | N/A                      |
+|     `xml.indent` |      `2`      | N/A                      |
 
 For example, this is how you would disable the default header and JSON key
 sorting, and specify a custom JSON indent size:
@@ -1237,11 +1236,10 @@ sorting-related format options (currently it means JSON keys and headers):
 
 This is something you will typically store as one of the default options in your [config](#config) file.
 
-#### Response `Content-Type`
+### Response `Content-Type`
 
-The `--response-as=value` option is a shortcut for `--format-options response.as:value`,
-and it allows you to override the response `Content-Type` sent by the server.
-That makes it possible for HTTPie to pretty-print the response even when the server specifies the type incorrectly.
+The `--response-as=value` option allows you to override the response `Content-Type` sent by the server.
+That makes it possible for HTTPie to print the response even when the server specifies the type incorrectly.
 
 For example, the following request will force the response to be treated as XML:
 

--- a/httpie/cli/argparser.py
+++ b/httpie/cli/argparser.py
@@ -458,8 +458,6 @@ class HTTPieArgumentParser(argparse.ArgumentParser):
 
     def _process_format_options(self):
         format_options = self.args.format_options or []
-        if self.args.response_as is not None:
-            format_options.append('response.as:' + self.args.response_as)
         parsed_options = PARSED_DEFAULT_FORMAT_OPTIONS
         for options_group in format_options:
             parsed_options = parse_format_options(options_group, defaults=parsed_options)

--- a/httpie/cli/constants.py
+++ b/httpie/cli/constants.py
@@ -85,13 +85,11 @@ PRETTY_MAP = {
 PRETTY_STDOUT_TTY_ONLY = object()
 
 
-EMPTY_FORMAT_OPTION = "''"
 DEFAULT_FORMAT_OPTIONS = [
     'headers.sort:true',
     'json.format:true',
     'json.indent:4',
     'json.sort_keys:true',
-    'response.as:' + EMPTY_FORMAT_OPTION,
     'xml.format:true',
     'xml.indent:2',
 ]

--- a/httpie/cli/definition.py
+++ b/httpie/cli/definition.py
@@ -313,15 +313,12 @@ output_processing.add_argument(
     '--response-as',
     metavar='CONTENT_TYPE',
     help='''
-    Override the response Content-Type for formatting purposes, e.g.:
+    Override the response Content-Type for display purposes, e.g.:
 
         --response-as=application/xml
         --response-as=charset=utf-8
         --response-as='application/xml; charset=utf-8'
 
-    It is a shortcut for:
-
-        --format-options=response.as:CONTENT_TYPE
     '''
 )
 

--- a/httpie/output/processing.py
+++ b/httpie/output/processing.py
@@ -33,7 +33,6 @@ class Formatting:
         :param kwargs: additional keyword arguments for processors
 
         """
-        self.options = kwargs['format_options']
         available_plugins = plugin_manager.get_formatters_grouped()
         self.enabled_plugins = []
         for group in groups:

--- a/httpie/output/writer.py
+++ b/httpie/output/writer.py
@@ -134,23 +134,23 @@ def get_stream_type_and_kwargs(
                 else RawStream.CHUNK_SIZE
             )
         }
-    elif args.prettify:
-        stream_class = PrettyStream if args.stream else BufferedPrettyStream
-        stream_kwargs = {
-            'env': env,
-            'conversion': Conversion(),
-            'formatting': Formatting(
-                env=env,
-                groups=args.prettify,
-                color_scheme=args.style,
-                explicit_json=args.json,
-                format_options=args.format_options,
-            )
-        }
     else:
         stream_class = EncodedStream
         stream_kwargs = {
-            'env': env
+            'env': env,
+            'response_as': args.response_as,
         }
+        if args.prettify:
+            stream_class = PrettyStream if args.stream else BufferedPrettyStream
+            stream_kwargs.update({
+                'conversion': Conversion(),
+                'formatting': Formatting(
+                    env=env,
+                    groups=args.prettify,
+                    color_scheme=args.style,
+                    explicit_json=args.json,
+                    format_options=args.format_options,
+                )
+            })
 
     return stream_class, stream_kwargs

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -377,9 +377,6 @@ class TestFormatOptions:
                         'indent': 10,
                         'format': True
                     },
-                    'response': {
-                        'as': "''",
-                    },
                     'xml': {
                         'format': True,
                         'indent': 2,
@@ -399,9 +396,6 @@ class TestFormatOptions:
                         'indent': 4,
                         'format': True
                     },
-                    'response': {
-                        'as': "''",
-                    },
                     'xml': {
                         'format': True,
                         'indent': 2,
@@ -423,9 +417,6 @@ class TestFormatOptions:
                         'indent': 4,
                         'format': True
                     },
-                    'response': {
-                        'as': "''",
-                    },
                     'xml': {
                         'format': True,
                         'indent': 2,
@@ -444,7 +435,6 @@ class TestFormatOptions:
             (
                 [
                     '--format-options=json.indent:2',
-                    '--format-options=response.as:application/xml; charset=utf-8',
                     '--format-options=xml.format:false',
                     '--format-options=xml.indent:4',
                     '--unsorted',
@@ -458,9 +448,6 @@ class TestFormatOptions:
                         'sort_keys': True,
                         'indent': 2,
                         'format': True
-                    },
-                    'response': {
-                        'as': 'application/xml; charset=utf-8',
                     },
                     'xml': {
                         'format': False,
@@ -483,9 +470,6 @@ class TestFormatOptions:
                         'indent': 2,
                         'format': True
                     },
-                    'response': {
-                        'as': "''",
-                    },
                     'xml': {
                         'format': True,
                         'indent': 2,
@@ -507,9 +491,6 @@ class TestFormatOptions:
                         'sort_keys': True,
                         'indent': 2,
                         'format': True
-                    },
-                    'response': {
-                        'as': "''",
                     },
                     'xml': {
                         'format': True,

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -87,29 +87,9 @@ def test_invalid_xml(file):
 
 
 @responses.activate
-def test_content_type_from_format_options_argument():
+def test_content_type_from_option():
     """Test XML response with a incorrect Content-Type header.
-    Using the --format-options to force the good one.
-    """
-    responses.add(responses.GET, URL_EXAMPLE, body=XML_DATA_RAW,
-                  content_type='plain/text')
-    args = ('--format-options', 'response.as:application/xml',
-            URL_EXAMPLE)
-
-    # Ensure the option is taken into account only for responses.
-    # Request
-    r = http('--offline', '--raw', XML_DATA_RAW, *args)
-    assert XML_DATA_RAW in r
-
-    # Response
-    r = http(*args)
-    assert XML_DATA_FORMATTED in r
-
-
-@responses.activate
-def test_content_type_from_shortcut_argument():
-    """Test XML response with a incorrect Content-Type header.
-    Using the --format-options shortcut to force the good one.
+    Using the --response-as option to force the good one.
     """
     responses.add(responses.GET, URL_EXAMPLE, body=XML_DATA_RAW,
                   content_type='text/plain')
@@ -126,9 +106,9 @@ def test_content_type_from_shortcut_argument():
 
 
 @responses.activate
-def test_content_type_from_incomplete_format_options_argument():
+def test_content_type_from_option_incomplete():
     """Test XML response with a incorrect Content-Type header.
-    Using the --format-options to use a partial Content-Type without mime type.
+    Using the --response-as option to set a partial Content-Type without mime type.
     """
     responses.add(responses.GET, URL_EXAMPLE, body=XML_DATA_RAW,
                   content_type='text/plain')


### PR DESCRIPTION
Proposal:

1. Move response `Content-Type` checks from the `PrettyStream` class to the `EncodedStream` parent class.
2. Remove `--format-option response.as` and promote `--response-as`: using the format option would be misleading as it is now can also be used for non-prettified responses.

Fixes #1167.