### PR TITLE
Strip leading `://` from URLs to allow quick conversion of a pasted URL to calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [2.7.0.dev0](https://github.com/httpie/httpie/compare/2.6.0...master) (unreleased)
 
 - Added support for sending multiple HTTP headers with the same name. ([#130](https://github.com/httpie/httpie/issues/130))
-- Added support for keeping `://` in the URL argument to allow quick conversions of pasted URLs into HTTPie calls just by adding a space after the protocol name (`$ https ://pie.dev/get` → `GET https://pie.dev/get`) . ([#1195](https://github.com/httpie/httpie/issues/1195))
+- Added support for keeping `://` in the URL argument to allow quick conversions of pasted URLs into HTTPie calls just by adding a space after the protocol name (`$ https ://pie.dev` → `https://pie.dev`) . ([#1195](https://github.com/httpie/httpie/issues/1195))
 
 ## [2.6.0](https://github.com/httpie/httpie/compare/2.5.0...2.6.0) (2021-10-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [2.7.0.dev0](https://github.com/httpie/httpie/compare/2.6.0...master) (unreleased)
 
 - Added support for sending multiple HTTP headers with the same name. ([#130](https://github.com/httpie/httpie/issues/130))
-- Added support for keeping `://` in the URL argument to allow quick conversions of pasted URLs into HTTPie calls just by adding a space after the protocol name (`$ https ://pie.dev` → `https://pie.dev`) . ([#1195](https://github.com/httpie/httpie/issues/1195))
+- Added support for keeping `://` in the URL argument to allow quick conversions of pasted URLs into HTTPie calls just by adding a space after the protocol name (`$ https ://pie.dev` → `https://pie.dev`). ([#1195](https://github.com/httpie/httpie/issues/1195))
 
 ## [2.6.0](https://github.com/httpie/httpie/compare/2.5.0...2.6.0) (2021-10-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [2.7.0.dev0](https://github.com/httpie/httpie/compare/2.6.0...master) (unreleased)
 
 - Added support for sending multiple HTTP headers with the same name. ([#130](https://github.com/httpie/httpie/issues/130))
+- Added support for keeping `://` in the URL argument to allow quick conversions of pasted URLs into HTTPie calls just by adding a space after the protocol name (`$ https ://pie.dev/get` → `GET https://pie.dev/get`) . ([#1195](https://github.com/httpie/httpie/issues/1195))
 
 ## [2.6.0](https://github.com/httpie/httpie/compare/2.5.0...2.6.0) (2021-10-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Fixed `--verbose` HTTP 307 redirects with streamed request body. ([#1088](https://github.com/httpie/httpie/issues/1088))
 - Fixed handling of session files with `Cookie:` followed by other headers. ([#1126](https://github.com/httpie/httpie/issues/1126))
 
-
 ## [2.4.0](https://github.com/httpie/httpie/compare/2.3.0...2.4.0) (2021-02-06)
 
 - Added support for `--session` cookie expiration based on `Set-Cookie: max-age=<n>`. ([#1029](https://github.com/httpie/httpie/issues/1029))

--- a/docs/README.md
+++ b/docs/README.md
@@ -495,13 +495,13 @@ $ https example.org
 When you paste a URL into the terminal, you can even keep the `://` bit in the URL argument to quickly convert the URL into an HTTPie call just by adding a space after the protocol name.
 
 ```bash
-# Paste https://example.org, add a space, submit:
 $ https ://example.org
+# → https://example.org
 ```
 
 ```bash
-# Paste http://example.org, add a space, submit:
 $ http ://example.org
+# → https://example.org
 ```
 
 ### Querystring parameters

--- a/docs/README.md
+++ b/docs/README.md
@@ -498,6 +498,7 @@ When you paste a URL into the terminal, you can even keep the `://` bit in the U
 # Paste https://example.org, add a space, submit:
 $ https ://example.org
 ```
+
 ```bash
 # Paste http://example.org, add a space, submit:
 $ http ://example.org
@@ -1957,7 +1958,6 @@ HTTPie has the following community channels:
 - [GitHub Issues](https://github.com/httpie/httpie/issues) for bug reports and feature requests
 - [Discord server](https://httpie.io/discord) to ask questions, discuss features, and for general API development discussion
 - [StackOverflow](https://stackoverflow.com) to ask questions (make sure to use the [httpie](https://stackoverflow.com/questions/tagged/httpie) tag)
-
 
 ### Related projects
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -482,14 +482,25 @@ The default scheme is `http://` and can be omitted from the argument:
 
 ```bash
 $ http example.org
-# => http://example.org
+# → http://example.org
 ```
 
 HTTPie also installs an `https` executable, where the default scheme is `https://`:
 
 ```bash
 $ https example.org
-# => https://example.org
+# → https://example.org
+```
+
+When you paste a URL into the terminal, you can even keep the `://` bit in the URL argument to quickly convert the URL into an HTTPie call just by adding a space after the protocol name.
+
+```bash
+# Paste https://example.org, add a space, submit:
+$ https ://example.org
+```
+```bash
+# Paste http://example.org, add a space, submit:
+$ http ://example.org
 ```
 
 ### Querystring parameters

--- a/docs/README.md
+++ b/docs/README.md
@@ -501,7 +501,7 @@ $ https ://example.org
 
 ```bash
 $ http ://example.org
-# → https://example.org
+# → http://example.org
 ```
 
 ### Querystring parameters

--- a/httpie/cli/argparser.py
+++ b/httpie/cli/argparser.py
@@ -121,7 +121,7 @@ class HTTPieArgumentParser(argparse.ArgumentParser):
 
     def _process_url(self):
         if self.args.url.startswith('://'):
-            # Paste URL & add space shortcut: `http ://pie.dev` → `GET https://pie.dev/get`
+            # Paste URL & add space shortcut: `http ://pie.dev` → `http://pie.dev`
             self.args.url = self.args.url[3:]
         if not URL_SCHEME_RE.match(self.args.url):
             if os.path.basename(self.env.program_name) == 'https':

--- a/httpie/cli/argparser.py
+++ b/httpie/cli/argparser.py
@@ -120,6 +120,9 @@ class HTTPieArgumentParser(argparse.ArgumentParser):
         }
 
     def _process_url(self):
+        if self.args.url.startswith('://'):
+            # Paste URL & add space shortcut: `http ://pie.dev` → `GET https://pie.dev/get`
+            self.args.url = self.args.url[3:]
         if not URL_SCHEME_RE.match(self.args.url):
             if os.path.basename(self.env.program_name) == 'https':
                 scheme = 'https://'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -173,7 +173,7 @@ class TestQuerystring:
     ('http', '://pie.dev/get', 'http://pie.dev/get'),
     ('https', '://pie.dev/get', 'https://pie.dev/get'),
 ])
-def test_colon_slash_slash(program_name, url_arg, parsed_url):
+def test_url_leading_colon_slash_slash(program_name, url_arg, parsed_url):
     env = MockEnvironment(program_name=program_name)
     args = parser.parse_args(args=[url_arg], env=env)
     assert args.url == parsed_url

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -169,6 +169,16 @@ class TestQuerystring:
         assert f'"url": "{url}"' in r
 
 
+@pytest.mark.parametrize(['program_name', 'url_arg', 'parsed_url'], [
+    ('http', '://pie.dev/get', 'http://pie.dev/get'),
+    ('https', '://pie.dev/get', 'https://pie.dev/get'),
+])
+def test_colon_slash_slash(program_name, url_arg, parsed_url):
+    env = MockEnvironment(program_name=program_name)
+    args = parser.parse_args(args=[url_arg], env=env)
+    assert args.url == parsed_url
+
+
 class TestLocalhostShorthand:
     def test_expand_localhost_shorthand(self):
         args = parser.parse_args(args=[':'], env=MockEnvironment())


### PR DESCRIPTION
Closes #1195

When you paste a URL into the terminal, you can even keep the `://` bit in the URL argument to quickly convert the URL into an HTTPie call just by adding a space after the protocol name.
```bash
# Paste https://example.org, add a space, submit:
$ https ://example.org
```
```bash
# Paste http://example.org, add a space, submit:
$ http ://example.org
```
