### PR TITLE
Change `PyPi` to `PyPI`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,7 @@ Do not edit here, but in docs/installation/.
 
 ### Universal
 
-#### PyPi
+#### PyPI
 
 Please make sure you have Python 3.6 or newer (`python --version`).
 

--- a/docs/installation/methods.yml
+++ b/docs/installation/methods.yml
@@ -171,7 +171,7 @@ tools:
         - port upgrade httpie
 
   pypi:
-    title: PyPi
+    title: PyPI
     name: pip
     note: Please make sure you have Python 3.6 or newer (`python --version`).
     links:


### PR DESCRIPTION
This pull request changes the acronym for the Python Packaging Index from it’s previous spelling of PyPi to PyPI.