### PR TITLE
core: support custom request/response classes

### DIFF
--- a/httpie/client.py
+++ b/httpie/client.py
@@ -4,7 +4,7 @@ import json
 import sys
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Callable, Iterable, Union
+from typing import Callable, Iterable
 from urllib.parse import urlparse, urlunparse
 
 import requests
@@ -20,7 +20,7 @@ from .uploads import (
     compress_request, prepare_request_body,
     get_multipart_data_and_content_type,
 )
-from .utils import get_expired_cookies, repr_dict
+from .utils import Message, get_expired_cookies, repr_dict
 
 
 urllib3.disable_warnings()
@@ -35,7 +35,7 @@ def collect_messages(
     args: argparse.Namespace,
     config_dir: Path,
     request_body_read_callback: Callable[[bytes], None] = None,
-) -> Iterable[Union[requests.PreparedRequest, requests.Response]]:
+) -> Iterable[Message]:
     httpie_session = None
     httpie_session_headers = None
     if args.session or args.session_read_only:

--- a/httpie/client.py
+++ b/httpie/client.py
@@ -13,6 +13,7 @@ import urllib3
 from . import __version__
 from .cli.dicts import RequestHeadersDict
 from .encoding import UTF8
+from .models import RequestsMessage
 from .plugins.registry import plugin_manager
 from .sessions import get_httpie_session
 from .ssl import AVAILABLE_SSL_VERSION_ARG_MAPPING, HTTPieHTTPSAdapter
@@ -20,7 +21,7 @@ from .uploads import (
     compress_request, prepare_request_body,
     get_multipart_data_and_content_type,
 )
-from .utils import Message, get_expired_cookies, repr_dict
+from .utils import get_expired_cookies, repr_dict
 
 
 urllib3.disable_warnings()
@@ -35,7 +36,7 @@ def collect_messages(
     args: argparse.Namespace,
     config_dir: Path,
     request_body_read_callback: Callable[[bytes], None] = None,
-) -> Iterable[Message]:
+) -> Iterable[RequestsMessage]:
     httpie_session = None
     httpie_session_headers = None
     if args.session or args.session_read_only:

--- a/httpie/core.py
+++ b/httpie/core.py
@@ -13,10 +13,14 @@ from .cli.constants import OUT_REQ_BODY, OUT_REQ_HEAD, OUT_RESP_BODY, OUT_RESP_H
 from .client import collect_messages
 from .context import Environment
 from .downloads import Downloader
+from .models import (
+    RequestsMessage,
+    RequestsMessageKind,
+    infer_requests_message_kind
+)
 from .output.writer import write_message, write_stream, MESSAGE_SEPARATOR_BYTES
 from .plugins.registry import plugin_manager
 from .status import ExitStatus, http_status_to_exit_status
-from .utils import Message, MessageType, infer_message_type
 
 
 # noinspection PyDefaultArgument
@@ -112,18 +116,18 @@ def main(args: List[Union[str, bytes]] = sys.argv, env=Environment()) -> ExitSta
 
 def get_output_options(
     args: argparse.Namespace,
-    message: Message
+    message: RequestsMessage
 ) -> Tuple[bool, bool]:
     return {
-        MessageType.REQUEST: (
+        RequestsMessageKind.REQUEST: (
             OUT_REQ_HEAD in args.output_options,
             OUT_REQ_BODY in args.output_options,
         ),
-        MessageType.RESPONSE: (
+        RequestsMessageKind.RESPONSE: (
             OUT_RESP_HEAD in args.output_options,
             OUT_RESP_BODY in args.output_options,
         ),
-    }[infer_message_type(message)]
+    }[infer_requests_message_kind(message)]
 
 
 def program(args: argparse.Namespace, env: Environment) -> ExitStatus:

--- a/httpie/core.py
+++ b/httpie/core.py
@@ -16,6 +16,7 @@ from .downloads import Downloader
 from .output.writer import write_message, write_stream, MESSAGE_SEPARATOR_BYTES
 from .plugins.registry import plugin_manager
 from .status import ExitStatus, http_status_to_exit_status
+from .utils import Message, MessageType, infer_message_type
 
 
 # noinspection PyDefaultArgument
@@ -111,18 +112,18 @@ def main(args: List[Union[str, bytes]] = sys.argv, env=Environment()) -> ExitSta
 
 def get_output_options(
     args: argparse.Namespace,
-    message: Union[requests.PreparedRequest, requests.Response]
+    message: Message
 ) -> Tuple[bool, bool]:
     return {
-        requests.PreparedRequest: (
+        MessageType.REQUEST: (
             OUT_REQ_HEAD in args.output_options,
             OUT_REQ_BODY in args.output_options,
         ),
-        requests.Response: (
+        MessageType.RESPONSE: (
             OUT_RESP_HEAD in args.output_options,
             OUT_RESP_BODY in args.output_options,
         ),
-    }[type(message)]
+    }[infer_message_type(message)]
 
 
 def program(args: argparse.Namespace, env: Environment) -> ExitStatus:

--- a/httpie/models.py
+++ b/httpie/models.py
@@ -1,4 +1,7 @@
-from typing import Iterable
+import requests
+
+from enum import Enum, auto
+from typing import Iterable, Union
 from urllib.parse import urlsplit
 
 from .utils import split_cookies, parse_content_type_header
@@ -116,3 +119,20 @@ class HTTPRequest(HTTPMessage):
             # Happens with JSON/form request data parsed from the command line.
             body = body.encode()
         return body or b''
+
+
+RequestsMessage = Union[requests.PreparedRequest, requests.Response]
+
+
+class RequestsMessageKind(Enum):
+    REQUEST = auto()
+    RESPONSE = auto()
+
+
+def infer_requests_message_kind(message: RequestsMessage) -> RequestsMessageKind:
+    if isinstance(message, requests.PreparedRequest):
+        return RequestsMessageKind.REQUEST
+    elif isinstance(message, requests.Response):
+        return RequestsMessageKind.RESPONSE
+    else:
+        raise TypeError(f"Unexpected message type: {type(message).__name__}")

--- a/httpie/output/writer.py
+++ b/httpie/output/writer.py
@@ -3,8 +3,14 @@ import errno
 from typing import IO, TextIO, Tuple, Type, Union
 
 from ..context import Environment
-from ..models import HTTPRequest, HTTPResponse, HTTPMessage
-from ..utils import Message, MessageType, infer_message_type
+from ..models import (
+    HTTPRequest,
+    HTTPResponse,
+    HTTPMessage,
+    RequestsMessage,
+    RequestsMessageKind,
+    infer_requests_message_kind
+)
 from .processing import Conversion, Formatting
 from .streams import (
     BaseStream, BufferedPrettyStream, EncodedStream, PrettyStream, RawStream,
@@ -16,7 +22,7 @@ MESSAGE_SEPARATOR_BYTES = MESSAGE_SEPARATOR.encode()
 
 
 def write_message(
-    requests_message: Message,
+    requests_message: RequestsMessage,
     env: Environment,
     args: argparse.Namespace,
     with_headers=False,
@@ -92,14 +98,14 @@ def write_stream_with_colors_win(
 def build_output_stream_for_message(
     args: argparse.Namespace,
     env: Environment,
-    requests_message: Message,
+    requests_message: RequestsMessage,
     with_headers: bool,
     with_body: bool,
 ):
     message_type = {
-        MessageType.REQUEST: HTTPRequest,
-        MessageType.RESPONSE: HTTPResponse,
-    }[infer_message_type(requests_message)]
+        RequestsMessageKind.REQUEST: HTTPRequest,
+        RequestsMessageKind.RESPONSE: HTTPResponse,
+    }[infer_requests_message_kind(requests_message)]
     stream_class, stream_kwargs = get_stream_type_and_kwargs(
         env=env,
         args=args,

--- a/httpie/output/writer.py
+++ b/httpie/output/writer.py
@@ -2,10 +2,9 @@ import argparse
 import errno
 from typing import IO, TextIO, Tuple, Type, Union
 
-import requests
-
 from ..context import Environment
 from ..models import HTTPRequest, HTTPResponse, HTTPMessage
+from ..utils import Message, MessageType, infer_message_type
 from .processing import Conversion, Formatting
 from .streams import (
     BaseStream, BufferedPrettyStream, EncodedStream, PrettyStream, RawStream,
@@ -17,7 +16,7 @@ MESSAGE_SEPARATOR_BYTES = MESSAGE_SEPARATOR.encode()
 
 
 def write_message(
-    requests_message: Union[requests.PreparedRequest, requests.Response],
+    requests_message: Message,
     env: Environment,
     args: argparse.Namespace,
     with_headers=False,
@@ -93,14 +92,14 @@ def write_stream_with_colors_win(
 def build_output_stream_for_message(
     args: argparse.Namespace,
     env: Environment,
-    requests_message: Union[requests.PreparedRequest, requests.Response],
+    requests_message: Message,
     with_headers: bool,
     with_body: bool,
 ):
     message_type = {
-        requests.PreparedRequest: HTTPRequest,
-        requests.Response: HTTPResponse,
-    }[type(requests_message)]
+        MessageType.REQUEST: HTTPRequest,
+        MessageType.RESPONSE: HTTPResponse,
+    }[infer_message_type(requests_message)]
     stream_class, stream_kwargs = get_stream_type_and_kwargs(
         env=env,
         args=args,

--- a/httpie/utils.py
+++ b/httpie/utils.py
@@ -4,15 +4,18 @@ import re
 import sys
 import time
 from collections import OrderedDict
+from enum import Enum, auto
 from http.cookiejar import parse_ns_headers
 from pprint import pformat
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple, Union
 
+import requests
 import requests.auth
 
 RE_COOKIE_SPLIT = re.compile(r', (?=[^ ;]+=)')
 Item = Tuple[str, Any]
 Items = List[Item]
+Message = Union[requests.PreparedRequest, requests.Response]
 
 
 class JsonDictPreservingDuplicateKeys(OrderedDict):
@@ -207,3 +210,17 @@ def parse_content_type_header(header):
                 value = param[index_of_equals + 1:].strip(items_to_strip)
             params_dict[key.lower()] = value
     return content_type, params_dict
+
+
+class MessageType(Enum):
+    REQUEST = auto()
+    RESPONSE = auto()
+
+
+def infer_message_type(message: Message) -> MessageType:
+    if isinstance(message, requests.PreparedRequest):
+        return MessageType.REQUEST
+    elif isinstance(message, requests.Response):
+        return MessageType.RESPONSE
+    else:
+        raise TypeError(f"Unexpected message type: {type(message).__name__}")

--- a/httpie/utils.py
+++ b/httpie/utils.py
@@ -4,18 +4,15 @@ import re
 import sys
 import time
 from collections import OrderedDict
-from enum import Enum, auto
 from http.cookiejar import parse_ns_headers
 from pprint import pformat
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple
 
-import requests
 import requests.auth
 
 RE_COOKIE_SPLIT = re.compile(r', (?=[^ ;]+=)')
 Item = Tuple[str, Any]
 Items = List[Item]
-Message = Union[requests.PreparedRequest, requests.Response]
 
 
 class JsonDictPreservingDuplicateKeys(OrderedDict):
@@ -210,17 +207,3 @@ def parse_content_type_header(header):
                 value = param[index_of_equals + 1:].strip(items_to_strip)
             params_dict[key.lower()] = value
     return content_type, params_dict
-
-
-class MessageType(Enum):
-    REQUEST = auto()
-    RESPONSE = auto()
-
-
-def infer_message_type(message: Message) -> MessageType:
-    if isinstance(message, requests.PreparedRequest):
-        return MessageType.REQUEST
-    elif isinstance(message, requests.Response):
-        return MessageType.RESPONSE
-    else:
-        raise TypeError(f"Unexpected message type: {type(message).__name__}")


### PR DESCRIPTION
While playing with a 3rd party extension (httpie-gssapi), I've noticed that it sometimes get broken due to the hard-coded `requests` classes. `requests` plugins like `requests-gssapi` might return different type of request/response classes like [requests_gssapi.gssapi_.SanitizedResponse](https://github.com/pythongssapi/requests-gssapi/blob/0402d14235783716635a1ea08bd0b1c63dc69272/requests_gssapi/gssapi_.py#L34-L60) which makes sense depending on the use case. But since some of the places within `httpie` hard codes this, it is impossible to get around of it (it uses `type(message)` instead of `isinstance()` etc. checks). 

This patch simply abstracts request/response inference to it's own unit, and simplifies this process by changing the default type resolution from bare `type()` checks to `isinstance()` checks so all classes of the `reqeusts.Response` and `requests.PreparedRequest` will be supported with this.