### PR TITLE
Fix packit CI

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,7 +3,8 @@
 specfile_path: httpie.spec
 actions:
   # get the current Fedora Rawhide specfile:
-  post-upstream-clone: "wget https://src.fedoraproject.org/rpms/httpie/raw/rawhide/f/httpie.spec -O httpie.spec"
+  # post-upstream-clone: "wget https://src.fedoraproject.org/rpms/httpie/raw/rawhide/f/httpie.spec -O httpie.spec"
+  post-upstream-clone: "cp docs/packaging/linux-fedora/httpie.spec.txt httpie.spec"
 jobs:
 - job: copr_build
   trigger: pull_request

--- a/docs/packaging/linux-fedora/httpie.spec.txt
+++ b/docs/packaging/linux-fedora/httpie.spec.txt
@@ -56,6 +56,7 @@ export PYTHONPATH=%{buildroot}%{python3_sitelib}
 mkdir -p %{buildroot}%{_mandir}/man1
 help2man %{buildroot}%{_bindir}/http > %{buildroot}%{_mandir}/man1/http.1
 help2man %{buildroot}%{_bindir}/https > %{buildroot}%{_mandir}/man1/https.1
+help2man %{buildroot}%{_bindir}/httpie > %{buildroot}%{_mandir}/man1/httpie.1
 
 
 %check
@@ -67,8 +68,10 @@ help2man %{buildroot}%{_bindir}/https > %{buildroot}%{_mandir}/man1/https.1
 %license LICENSE
 %{_bindir}/http
 %{_bindir}/https
+%{_bindir}/httpie
 %{_mandir}/man1/http.1*
 %{_mandir}/man1/https.1*
+%{_mandir}/man1/httpie.1*
 # we co-own the entire directory structures for bash/fish completion to avoid a dependency
 %{_datadir}/bash-completion/
 %{_datadir}/fish/

--- a/httpie/manager/plugins.py
+++ b/httpie/manager/plugins.py
@@ -8,10 +8,8 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Optional, List
 
-import importlib_metadata
-
 from httpie.manager.cli import parser, missing_subcommand
-from httpie.compat import get_dist_name
+from httpie.compat import importlib_metadata, get_dist_name
 from httpie.context import Environment
 from httpie.status import ExitStatus
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ install_requires = [
     'requests-toolbelt>=0.9.1',
     'multidict>=4.7.0',
     'setuptools',
-    'importlib-metadata>=1.4.0',
+    'importlib-metadata>=1.4.0; python_version < "3.8"',
 ]
 install_requires_win_only = [
     'colorama>=0.2.4',


### PR DESCRIPTION
Currently, the package in the Fedora repositories doesn't match the master, since we've added a new command. But packit doesn't know that and tries to build from the master with the 2.6.0 release spec file. This patch reconfigures packit to use our own locally hosted specfile.