### PR TITLE
brew: add multidict

### DIFF
--- a/docs/packaging/brew/brew-deps.py
+++ b/docs/packaging/brew/brew-deps.py
@@ -31,6 +31,7 @@ PACKAGES = [
     'requests',
     'requests-toolbelt',
     'urllib3',
+    'multidict',
 ]
 
 

--- a/docs/packaging/brew/httpie.rb
+++ b/docs/packaging/brew/httpie.rb
@@ -63,6 +63,11 @@ class Httpie < Formula
     sha256 "4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece"
   end
 
+  resource "multidict" do
+    url "https://files.pythonhosted.org/packages/8e/7c/e12a69795b7b7d5071614af2c691c97fbf16a2a513c66ec52dd7d0a115bb/multidict-5.2.0.tar.gz"
+    sha256 "0dd1c93edb444b33ba2274b66f63def8a327d607c6c790772f448a53b6ea59ce"
+  end
+
   def install
     virtualenv_install_with_resources
   end


### PR DESCRIPTION
multidict is needed for multiple headers with the same name, other than that the new `importlib-metadataa` dependency is not needed since brew packages for 3.10 (it is in the stdlib since 3.8+)!