### PR TITLE
Fix snapcraft packaging

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -64,18 +64,13 @@ parts:
       python -m pip install httpie-unixsocket
       python -m pip install httpie-snapdsocket
 
-      echo "Removing no more needed modules ..."
-      python -m pip uninstall -y pip wheel
-
     override-prime: |
       snapcraftctl prime
 
       echo "Removing useless files ..."
       packages=$SNAPCRAFT_PRIME/lib/python3.8/site-packages
-      rm -rfv $packages/_distutils_hack
       rm -rfv $packages/pkg_resources/tests
       rm -rfv $packages/requests_unixsocket/test*
-      rm -rfv $packages/setuptools
 
       echo "Compiling pyc files ..."
       python -m compileall -f $packages
@@ -110,5 +105,11 @@ apps:
     command: bin/https
     plugs: *plugs
     completer: httpie-completion.bash
+    environment:
+      LC_ALL: C.UTF-8
+
+  httpie:
+    command: bin/httpie
+    plugs: *plugs
     environment:
       LC_ALL: C.UTF-8


### PR DESCRIPTION
We now bundle both `pip` and `setuptools` (needed for plugin installation). As well as export the `httpie` command itself.