### PR TITLE
Optimize encoding detection

### DIFF
--- a/extras/profiling/benchmarks.py
+++ b/extras/profiling/benchmarks.py
@@ -178,9 +178,8 @@ for pretty in ['all', 'none']:
         f'`http --pretty={pretty} pie.dev/stream/1000`',
         [
             '--print=HBhb',
-            '--stream',
             f'--pretty={pretty}',
-            'httpbin.org/stream/100'
+            'httpbin.org/stream/1000'
         ]
     )
 DownloadRunner('download', '`http --download :/big_file.txt` (3GB)', '3G')

--- a/httpie/encoding.py
+++ b/httpie/encoding.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Tuple
 
 from charset_normalizer import from_bytes
 from charset_normalizer.constant import TOO_SMALL_SEQUENCE
@@ -29,7 +29,7 @@ def detect_encoding(content: ContentBytes) -> str:
     return encoding
 
 
-def smart_decode(content: ContentBytes, encoding: str) -> str:
+def smart_decode(content: ContentBytes, encoding: str) -> Tuple[str, str]:
     """Decode `content` using the given `encoding`.
     If no `encoding` is provided, the best effort is to guess it from `content`.
 
@@ -38,7 +38,7 @@ def smart_decode(content: ContentBytes, encoding: str) -> str:
     """
     if not encoding:
         encoding = detect_encoding(content)
-    return content.decode(encoding, 'replace')
+    return content.decode(encoding, 'replace'), encoding
 
 
 def smart_encode(content: str, encoding: str) -> bytes:

--- a/httpie/output/streams.py
+++ b/httpie/output/streams.py
@@ -125,7 +125,7 @@ class EncodedStream(BaseStream):
         for line, lf in self.msg.iter_lines(self.CHUNK_SIZE):
             if b'\0' in line:
                 raise BinarySuppressedError()
-            line = smart_decode(line, self.encoding)
+            line, self.encoding = smart_decode(line, self.encoding)
             yield smart_encode(line, self.output_encoding) + lf
 
 
@@ -178,7 +178,7 @@ class PrettyStream(EncodedStream):
         if not isinstance(chunk, str):
             # Text when a converter has been used,
             # otherwise it will always be bytes.
-            chunk = smart_decode(chunk, self.encoding)
+            chunk, self.encoding = smart_decode(chunk, self.encoding)
         chunk = self.formatting.format_body(content=chunk, mime=self.mime)
         return smart_encode(chunk, self.output_encoding)
 

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -32,6 +32,8 @@ JSON_FILE_PATH_ARG = patharg(JSON_FILE_PATH)
 # line would be escaped).
 FILE_CONTENT = FILE_PATH.read_text(encoding=UTF8).strip()
 
+ASCII_FILE_CONTENT = "random text" * 10
+
 
 JSON_FILE_CONTENT = JSON_FILE_PATH.read_text(encoding=UTF8)
 BIN_FILE_CONTENT = BIN_FILE_PATH.read_bytes()

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -11,7 +11,12 @@ from httpie.plugins import ConverterPlugin
 from httpie.plugins.registry import plugin_manager
 
 from .utils import StdinBytesIO, http, MockEnvironment, DUMMY_URL
-from .fixtures import BIN_FILE_CONTENT, BIN_FILE_PATH
+from .fixtures import (
+    ASCII_FILE_CONTENT,
+    BIN_FILE_CONTENT,
+    BIN_FILE_PATH,
+    FILE_CONTENT as UNICODE_FILE_CONTENT
+)
 
 PRETTY_OPTIONS = list(PRETTY_MAP.keys())
 
@@ -133,3 +138,9 @@ def test_auto_streaming(http_server, extras, expected):
         for call_arg in env.stdout.write.call_args_list
         if b'test' in call_arg[0][0]
     ]) == expected
+
+
+def test_streaming_encoding_detection(http_server):
+    r = http('--stream', http_server + '/stream/encoding/random')
+    assert ASCII_FILE_CONTENT in r
+    assert UNICODE_FILE_CONTENT in r

--- a/tests/utils/http_server.py
+++ b/tests/utils/http_server.py
@@ -52,6 +52,27 @@ def chunked_drip(handler):
     handler.wfile.write('0\r\n\r\n'.encode('utf-8'))
 
 
+@TestHandler.handler('GET', '/stream/encoding/random')
+def random_encoding(handler):
+    from tests.fixtures import ASCII_FILE_CONTENT, FILE_CONTENT as UNICODE_FILE_CONTENT
+
+    handler.send_response(200)
+    handler.send_header('Transfer-Encoding', 'chunked')
+    handler.end_headers()
+
+    for body in [
+        ASCII_FILE_CONTENT,
+        ASCII_FILE_CONTENT,
+        UNICODE_FILE_CONTENT,
+        UNICODE_FILE_CONTENT,
+        UNICODE_FILE_CONTENT,
+    ]:
+        body += "\n"
+        handler.wfile.write(f'{len(body.encode()):X}\r\n{body}\r\n'.encode())
+
+    handler.wfile.write('0\r\n\r\n'.encode('utf-8'))
+
+
 @pytest.fixture(scope="function")
 def http_server():
     """A custom HTTP server implementation for our tests, that is


### PR DESCRIPTION
In the past we detected encoding once per chunk, which is very inefficient. Since if a chunk has a certain encoding, then the next one is going to be the same. This optimizes `--pretty={all, color, format}` by up to %35 (or even more if the response size is huge). 

Before:
```
Summary
  'http --print=HBhb --stream --ignore-stdin --pretty=none  pie.dev/stream/1000' ran
    1.45 ± 0.11 times faster than 'http --print=HBhb --stream --ignore-stdin --pretty=colors  pie.dev/stream/1000'
    1.47 ± 0.11 times faster than 'http --print=HBhb --stream --ignore-stdin --pretty=format  pie.dev/stream/1000'
    1.47 ± 0.08 times faster than 'http --print=HBhb --stream --ignore-stdin --pretty=all  pie.dev/stream/1000'
```

After:
```
Summary
  'http --print=HBhb --stream --ignore-stdin --pretty=format  pie.dev/stream/1000' ran
    1.02 ± 0.05 times faster than 'http --print=HBhb --stream --ignore-stdin --pretty=all  pie.dev/stream/1000'
    1.09 ± 0.10 times faster than 'http --print=HBhb --stream --ignore-stdin --pretty=none  pie.dev/stream/1000'
    1.11 ± 0.08 times faster than 'http --print=HBhb --stream --ignore-stdin --pretty=colors  pie.dev/stream/1000'
```