### PR TITLE
Strip out extra variables from the actual mime type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Added support for automatically enabling `--stream` when `Content-Type` is `text/event-stream`. ([#376](https://github.com/httpie/httpie/issues/376))
 - Broken plugins will no longer crash the whole application. ([#1204](https://github.com/httpie/httpie/issues/1204))
 - Fixed auto addition of XML declaration to every formatted XML response. ([#1156](https://github.com/httpie/httpie/issues/1156))
+- Fixed highlighting when `Content-Type` specifies an additional charset. ([#1242](https://github.com/httpie/httpie/issues/1242))
 
 ## [2.6.0](https://github.com/httpie/httpie/compare/2.5.0...2.6.0) (2021-10-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Added support for automatically enabling `--stream` when `Content-Type` is `text/event-stream`. ([#376](https://github.com/httpie/httpie/issues/376))
 - Broken plugins will no longer crash the whole application. ([#1204](https://github.com/httpie/httpie/issues/1204))
 - Fixed auto addition of XML declaration to every formatted XML response. ([#1156](https://github.com/httpie/httpie/issues/1156))
-- Fixed highlighting when `Content-Type` specifies an additional charset. ([#1242](https://github.com/httpie/httpie/issues/1242))
+- Fixed highlighting when `Content-Type` specifies `charset`. ([#1242](https://github.com/httpie/httpie/issues/1242))
 
 ## [2.6.0](https://github.com/httpie/httpie/compare/2.5.0...2.6.0) (2021-10-14)
 

--- a/httpie/output/streams.py
+++ b/httpie/output/streams.py
@@ -6,6 +6,7 @@ from .processing import Conversion, Formatting
 from ..context import Environment
 from ..encoding import smart_decode, smart_encode, UTF8
 from ..models import HTTPMessage
+from ..utils import parse_content_type_header
 
 
 BINARY_SUPPRESSED_NOTICE = (
@@ -106,7 +107,10 @@ class EncodedStream(BaseStream):
         **kwargs
     ):
         super().__init__(**kwargs)
-        self.mime = mime_overwrite or self.msg.content_type
+        if mime_overwrite:
+            self.mime = mime_overwrite
+        else:
+            self.mime, _ = parse_content_type_header(self.msg.content_type)
         self.encoding = encoding_overwrite or self.msg.encoding
         if env.stdout_isatty:
             # Use the encoding supported by the terminal.

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -223,7 +223,7 @@ class TestColors:
 ])
 def test_ensure_contents_colored(httpbin, endpoint):
     env = MockEnvironment(colors=256)
-    r = http('GET', httpbin + endpoint, env=env)
+    r = http('--body', 'GET', httpbin + endpoint, env=env)
     assert COLOR in r
 
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -215,6 +215,18 @@ class TestColors:
         assert get_lexer('xxx/yyy') is None
 
 
+@pytest.mark.parametrize("endpoint", [
+    "/encoding/utf8",
+    "/html",
+    "/json",
+    "/xml",
+])
+def test_ensure_contents_colored(httpbin, endpoint):
+    env = MockEnvironment(colors=256)
+    r = http('GET', httpbin + endpoint, env=env)
+    assert COLOR in r
+
+
 class TestPrettyOptions:
     """Test the --pretty handling."""
 


### PR DESCRIPTION
Resolves #1242. We used to pass the whole `Content-Type` header as the mime (including the stuff like `;charset=utf-8` and other variables), with this patch we now only pass the actual mime type.