### PR TITLE
Change the default style for windows from fruity to auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Fixed auto addition of XML declaration to every formatted XML response. ([#1156](https://github.com/httpie/httpie/issues/1156))
 - Fixed highlighting when `Content-Type` specifies `charset`. ([#1242](https://github.com/httpie/httpie/issues/1242))
 - Fixed an unexpected crash when `--raw` is used with `--chunked`. ([#1253](https://github.com/httpie/httpie/issues/1253))
+- Changed the default Windows theme from `fruity` to `auto`. ([#1266](https://github.com/httpie/httpie/issues/1266))
 
 ## [2.6.0](https://github.com/httpie/httpie/compare/2.5.0...2.6.0) (2021-10-14)
 

--- a/httpie/output/formatters/colors.py
+++ b/httpie/output/formatters/colors.py
@@ -18,7 +18,6 @@ from pygments.util import ClassNotFound
 from ..lexers.json import EnhancedJsonLexer
 from ..lexers.metadata import MetadataLexer
 from ..ui.palette import SHADE_NAMES, get_color
-from ...compat import is_windows
 from ...context import Environment
 from ...plugins import FormatterPlugin
 
@@ -26,11 +25,6 @@ from ...plugins import FormatterPlugin
 AUTO_STYLE = 'auto'  # Follows terminal ANSI color styles
 DEFAULT_STYLE = AUTO_STYLE
 SOLARIZED_STYLE = 'solarized'  # Bundled here
-
-if is_windows:
-    # Colors on Windows via colorama don't look that
-    # great and fruity seems to give the best result there.
-    DEFAULT_STYLE = 'fruity'
 
 BUNDLED_STYLES = {
     SOLARIZED_STYLE,

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -6,7 +6,6 @@ import responses
 from httpie.cli.constants import PRETTY_MAP
 from httpie.cli.exceptions import ParseError
 from httpie.cli.nested_json import HTTPieSyntaxError
-from httpie.compat import is_windows
 from httpie.output.formatters.colors import ColorFormatter
 from httpie.utils import JsonDictPreservingDuplicateKeys
 
@@ -39,7 +38,7 @@ TEST_JSON_VALUES = [
     False,
     None,
 ]
-TEST_PREFIX_TOKEN_COLOR = '\x1b[38;5;15m' if is_windows else '\x1b[04m\x1b[91m'
+TEST_PREFIX_TOKEN_COLOR = '\x1b[04m\x1b[91m'
 
 JSON_WITH_DUPES_RAW = '{"key": 15, "key": 15, "key": 3, "key": 7}'
 JSON_WITH_DUPES_FORMATTED_SORTED = """{


### PR DESCRIPTION
Fixes #1266. The documentation already claims that 'auto' is the default style HTTPie follows, so no need to make any edits there.