### PR TITLE
Mark test_stdin_read_warning with requires_installation

### DIFF
--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -138,6 +138,7 @@ def test_reading_from_stdin(httpbin, wait):
         assert b'> warning: no stdin data read in 0.1s' not in errs
 
 
+@pytest.mark.requires_installation
 @pytest.mark.skipif(is_windows, reason="Windows doesn't support select() calls into files")
 def test_stdin_read_warning(httpbin):
     with stdin_processes(httpbin) as (process_1, process_2):


### PR DESCRIPTION
https://github.com/httpie/httpie/issues/1276

Mark `test_stdin_read_warning` test case with `requires_installation`