### PR TITLE
Mark stdin warning related tests with `requires_external_processes`

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,7 @@
 [pytest]
 markers =
+    # If you want to run tests without a full HTTPie installation
+    # we advise you to disable the markers below, e.g:
+    # pytest -m 'not requires_installation and not requires_external_processes'
     requires_installation
+    requires_external_processes

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -121,6 +121,7 @@ def stdin_processes(httpbin, *args):
 
 
 @pytest.mark.parametrize("wait", (True, False))
+@pytest.mark.requires_external_processes
 @pytest.mark.skipif(is_windows, reason="Windows doesn't support select() calls into files")
 def test_reading_from_stdin(httpbin, wait):
     with stdin_processes(httpbin) as (process_1, process_2):
@@ -138,7 +139,7 @@ def test_reading_from_stdin(httpbin, wait):
         assert b'> warning: no stdin data read in 0.1s' not in errs
 
 
-@pytest.mark.requires_installation
+@pytest.mark.requires_external_processes
 @pytest.mark.skipif(is_windows, reason="Windows doesn't support select() calls into files")
 def test_stdin_read_warning(httpbin):
     with stdin_processes(httpbin) as (process_1, process_2):
@@ -154,6 +155,7 @@ def test_stdin_read_warning(httpbin):
         assert b'> warning: no stdin data read in 0.1s' in errs
 
 
+@pytest.mark.requires_external_processes
 @pytest.mark.skipif(is_windows, reason="Windows doesn't support select() calls into files")
 def test_stdin_read_warning_with_quiet(httpbin):
     with stdin_processes(httpbin, "-qq") as (process_1, process_2):

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -138,6 +138,7 @@ def test_reading_from_stdin(httpbin, wait):
         assert b'> warning: no stdin data read in 0.1s' not in errs
 
 
+@pytest.mark.requires_installation
 @pytest.mark.skipif(is_windows, reason="Windows doesn't support select() calls into files")
 def test_stdin_read_warning(httpbin):
     with stdin_processes(httpbin) as (process_1, process_2):


### PR DESCRIPTION
Cherry-picks and closes #1287