### PR TITLE
Regulate top-level arrays

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -875,6 +875,7 @@ $ http --offline --print=B pie.dev/post \
 ```
 
 You can also apply the nesting to the items by referencing their index:
+
 ```bash
 http --offline --print=B pie.dev/post \
     [0][type]=platform [0][name]=terminal \

--- a/docs/README.md
+++ b/docs/README.md
@@ -854,6 +854,46 @@ $ http PUT pie.dev/put \
 
 #### Advanced usage
 
+##### Top level arrays
+
+If you want to send an array instead of a regular object, you can simply
+do that by omitting the starting key:
+
+```bash
+$ http --offline --print=B pie.dev/post \
+    []:=1 \
+    []:=2 \
+    []:=3
+```
+
+```json
+[
+    1,
+    2,
+    3
+]
+```
+
+You can also apply the nesting to the items by referencing their index:
+```bash
+http --offline --print=B pie.dev/post \
+    [0][type]=platform [0][name]=terminal \
+    [1][type]=platform [1][name]=desktop
+```
+
+```json
+[
+    {
+        "type": "platform",
+        "name": "terminal"
+    },
+    {
+        "type": "platform",
+        "name": "desktop"
+    }
+]
+```
+
 ##### Escaping behavior
 
 Nested JSON syntax uses the same [escaping rules](#escaping-rules) as

--- a/httpie/cli/constants.py
+++ b/httpie/cli/constants.py
@@ -127,6 +127,7 @@ class RequestType(enum.Enum):
     JSON = enum.auto()
 
 
+EMPTY_STRING = ''
 OPEN_BRACKET = '['
 CLOSE_BRACKET = ']'
 BACKSLASH = '\\'

--- a/httpie/cli/dicts.py
+++ b/httpie/cli/dicts.py
@@ -82,3 +82,7 @@ class MultipartRequestDataDict(MultiValueOrderedDict):
 
 class RequestFilesDict(RequestDataDict):
     pass
+
+
+class NestedJSONArray(list):
+    """Denotes a top-level JSON array."""

--- a/httpie/cli/nested_json.py
+++ b/httpie/cli/nested_json.py
@@ -9,6 +9,7 @@ from typing import (
     Type,
     Union,
 )
+from httpie.cli.dicts import NestedJSONArray
 from httpie.cli.constants import EMPTY_STRING, OPEN_BRACKET, CLOSE_BRACKET, BACKSLASH, HIGHLIGHTER
 
 
@@ -377,7 +378,7 @@ def wrap_with_dict(context):
     if context is None:
         return {}
     elif isinstance(context, list):
-        return {EMPTY_STRING: context}
+        return {EMPTY_STRING: NestedJSONArray(context)}
     else:
         assert isinstance(context, dict)
         return context

--- a/httpie/client.py
+++ b/httpie/client.py
@@ -14,7 +14,7 @@ from . import __version__
 from .adapters import HTTPieHTTPAdapter
 from .context import Environment
 from .cli.constants import EMPTY_STRING
-from .cli.dicts import HTTPHeadersDict
+from .cli.dicts import HTTPHeadersDict, NestedJSONArray
 from .encoding import UTF8
 from .models import RequestsMessage
 from .plugins.registry import plugin_manager
@@ -281,7 +281,8 @@ def json_dict_to_request_body(data: Dict[str, Any]) -> str:
     # item in the object, with an en empty key.
     if len(data) == 1:
         [(key, value)] = data.items()
-        if key == EMPTY_STRING and isinstance(value, list):
+        if isinstance(value, NestedJSONArray):
+            assert key == EMPTY_STRING
             data = value
 
     if data:

--- a/httpie/client.py
+++ b/httpie/client.py
@@ -13,6 +13,7 @@ import urllib3
 from . import __version__
 from .adapters import HTTPieHTTPAdapter
 from .context import Environment
+from .cli.constants import EMPTY_STRING
 from .cli.dicts import HTTPHeadersDict
 from .encoding import UTF8
 from .models import RequestsMessage
@@ -280,7 +281,7 @@ def json_dict_to_request_body(data: Dict[str, Any]) -> str:
     # item in the object, with an en empty key.
     if len(data) == 1:
         [(key, value)] = data.items()
-        if key == '' and isinstance(value, list):
+        if key == EMPTY_STRING and isinstance(value, list):
             data = value
 
     if data:

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -445,8 +445,10 @@ def test_complex_json_arguments_with_non_json(httpbin, request_type, value):
         ),
         (
             ['[][a][b][]:=1', '[0][a][b][]:=2', '[][]:=2'],
-            [{'a': {'b': [1, 2]}}, [2]]
-        )
+            [{'a': {'b': [1, 2]}}, [2]],
+        ),
+        ([':=[1,2,3]'], {'': [1, 2, 3]}),
+        ([':=[1,2,3]', 'foo=bar'], {'': [1, 2, 3], 'foo': 'bar'}),
     ],
 )
 def test_nested_json_syntax(input_json, expected_json, httpbin):
@@ -550,6 +552,14 @@ def test_nested_json_syntax(input_json, expected_json, httpbin):
         ),
         (
             ['[]:=2', 'x=y'],
+            "HTTPie Type Error: Can't perform 'key' based access on '' which has a type of 'array' but this operation requires a type of 'object'.",
+        ),
+        (
+            [':=[1,2,3]', '[]:=4'],
+            "HTTPie Type Error: Can't perform 'append' based access on '' which has a type of 'object' but this operation requires a type of 'array'.",
+        ),
+        (
+            ['[]:=4', ':=[1,2,3]'],
             "HTTPie Type Error: Can't perform 'key' based access on '' which has a type of 'array' but this operation requires a type of 'object'.",
         ),
     ],


### PR DESCRIPTION
Starting with the initial implementation (and later with the second one), we had a special/hidden feature called 'top-level arrays':
```
$ http --offline --print=B pie.dev/post []:=1 []:=2 []:=3

[
    1,
    2,
    3
]
```
This is a powerful syntax, since there weren't a way of creating/sending arrays in the past (without sending them as raw data). One thing that we skipped between two different implementations was to make this more stricter.

@ducaale previously started [a discussion](https://discord.com/channels/725351238698270761/801485021016752208/929057887685324821) but we did not made a resolution back then due to worries over this would block the empty-key usage. Now that those are answered in #1286, I think we should be able to make the handling of top-level lists more seriously.

### New handling
- This patch forbids the usage of key-paths without a preceding key `[foo]=bar` (and variants of this)
- If you need to embed such a structure, you can still continue to use `:={"foo": "bar"}`.
- Mixing top-level list usage with other keys is now forbidden. E.g:
```
$ http --offline --print=B pie.dev/post a:=1 []:=2
{
    "": [
        2
    ],
    "a": 1
}
```
