### PR TITLE
Make the naked invocation display a compacted help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Fixed escaping of integer indexes with multiple backslashes in the nested JSON builder. ([#1285](https://github.com/httpie/httpie/issues/1285))
 - Fixed displaying of status code without a status message on non-`auto` themes. ([#1300](https://github.com/httpie/httpie/issues/1300))
 - Improved regulation of top-level arrays. ([#1292](https://github.com/httpie/httpie/commit/225dccb2186f14f871695b6c4e0bfbcdb2e3aa28))
+- Improved UI layout for standalone invocations. ([#1296](https://github.com/httpie/httpie/pull/1296))
 - Double `--quiet` flags will now suppress all python level warnings. ([#1271](https://github.com/httpie/httpie/issues/1271))
 
 ## [3.0.2](https://github.com/httpie/httpie/compare/3.0.1...3.0.2) (2022-01-24)

--- a/httpie/cli/argparser.py
+++ b/httpie/cli/argparser.py
@@ -553,9 +553,8 @@ class HTTPieArgumentParser(BaseHTTPieArgumentParser):
                 error:
                     {message}
 
-                For more information:
-                    - Try running {self.prog} --help
-                    - Or visiting https://httpie.io/docs/cli
+                for more information:
+                    run '{self.prog} --help' or visit https://httpie.io/docs/cli
                 '''
             )
         )

--- a/tests/test_cli_ui.py
+++ b/tests/test_cli_ui.py
@@ -1,0 +1,84 @@
+import pytest
+import shutil
+import os
+import sys
+from tests.utils import http
+
+
+if sys.version_info >= (3, 9):
+    REQUEST_ITEM_MSG = "[REQUEST_ITEM ...]"
+else:
+    REQUEST_ITEM_MSG = "[REQUEST_ITEM [REQUEST_ITEM ...]]"
+
+
+NAKED_HELP_MESSAGE = f"""\
+usage:
+    http [METHOD] URL {REQUEST_ITEM_MSG}
+
+error:
+    the following arguments are required: URL
+
+For more information:
+    - Try running http --help
+    - Or visiting https://httpie.io/docs/cli
+
+"""
+
+NAKED_HELP_MESSAGE_PRETTY_WITH_NO_ARG = f"""\
+usage:
+    http [--pretty {{all,colors,format,none}}] [METHOD] URL {REQUEST_ITEM_MSG}
+
+error:
+    argument --pretty: expected one argument
+
+For more information:
+    - Try running http --help
+    - Or visiting https://httpie.io/docs/cli
+
+"""
+
+NAKED_HELP_MESSAGE_PRETTY_WITH_INVALID_ARG = f"""\
+usage:
+    http [--pretty {{all,colors,format,none}}] [METHOD] URL {REQUEST_ITEM_MSG}
+
+error:
+    argument --pretty: invalid choice: '$invalid' (choose from 'all', 'colors', 'format', 'none')
+
+For more information:
+    - Try running http --help
+    - Or visiting https://httpie.io/docs/cli
+
+"""
+
+
+PREDEFINED_TERMINAL_SIZE = (160, 80)
+
+
+@pytest.fixture(scope="function")
+def ignore_terminal_size(monkeypatch):
+    """Some tests wrap/crop the output depending on the
+    size of the executed terminal, which might not be consistent
+    through all runs.
+
+    This fixture ensures every run uses the same exact configuration.
+    """
+
+    def fake_terminal_size(*args, **kwargs):
+        return os.terminal_size(PREDEFINED_TERMINAL_SIZE)
+
+    # Setting COLUMNS as an env var is required for 3.8<
+    monkeypatch.setitem(os.environ, 'COLUMNS', str(PREDEFINED_TERMINAL_SIZE[0]))
+    monkeypatch.setattr(shutil, 'get_terminal_size', fake_terminal_size)
+
+
+@pytest.mark.parametrize(
+    'args, expected_msg', [
+        ([], NAKED_HELP_MESSAGE),
+        (['--pretty'], NAKED_HELP_MESSAGE_PRETTY_WITH_NO_ARG),
+        (['pie.dev', '--pretty'], NAKED_HELP_MESSAGE_PRETTY_WITH_NO_ARG),
+        (['--pretty', '$invalid'], NAKED_HELP_MESSAGE_PRETTY_WITH_INVALID_ARG),
+    ]
+)
+def test_naked_invocation(ignore_terminal_size, args, expected_msg):
+    result = http(*args, tolerate_error_exit_status=True)
+    assert result.stderr == expected_msg

--- a/tests/test_cli_ui.py
+++ b/tests/test_cli_ui.py
@@ -18,9 +18,8 @@ usage:
 error:
     the following arguments are required: URL
 
-For more information:
-    - Try running http --help
-    - Or visiting https://httpie.io/docs/cli
+for more information:
+    run 'http --help' or visit https://httpie.io/docs/cli
 
 """
 
@@ -31,9 +30,8 @@ usage:
 error:
     argument --pretty: expected one argument
 
-For more information:
-    - Try running http --help
-    - Or visiting https://httpie.io/docs/cli
+for more information:
+    run 'http --help' or visit https://httpie.io/docs/cli
 
 """
 
@@ -44,9 +42,8 @@ usage:
 error:
     argument --pretty: invalid choice: '$invalid' (choose from 'all', 'colors', 'format', 'none')
 
-For more information:
-    - Try running http --help
-    - Or visiting https://httpie.io/docs/cli
+for more information:
+    run 'http --help' or visit https://httpie.io/docs/cli
 
 """
 


### PR DESCRIPTION
E.g:
```console
$ http           
usage:
    http [METHOD] URL [REQUEST_ITEM ...]

error:
    the following arguments are required: URL

For more information:
    - Try running http --help
    - Or visiting https://httpie.io/docs/cli
```