### PR TITLE
Replaced unmaintained OAuth plugin with new httpie-oauth1 plugin.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1377,7 +1377,7 @@ Here are a few picks:
 - [httpie-jwt-auth](https://github.com/teracyhq/httpie-jwt-auth): JWTAuth (JSON Web Tokens)
 - [httpie-negotiate](https://github.com/ndzou/httpie-negotiate): SPNEGO (GSS Negotiate)
 - [httpie-ntlm](https://github.com/httpie/httpie-ntlm): NTLM (NT LAN Manager)
-- [httpie-oauth](https://github.com/httpie/httpie-oauth): OAuth
+- [httpie-oauth1](https://github.com/qcif/httpie-oauth1): OAuth 1.0a
 - [requests-hawk](https://github.com/mozilla-services/requests-hawk): Hawk
 
 See [plugin manager](#plugin-manager) for more details.


### PR DESCRIPTION
The old **httpie-oauth** plugin is incomplete and appears to have been abandoned. The project maintainer has not responded to Pull Requests or issues for [well over one year](https://github.com/httpie/httpie-oauth/issues/5).

Therefore, it should be replaced with this new **httpie-oauth1** plugin. Linking to its [GitHub repository](https://github.com/qcif/httpie) or its [package on PyPi](https://pypi.org/project/httpie-oauth1/).