### PR TITLE
Don't issue redundant stdin detection warning when  is in place.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - Fixed escaping of integer indexes with multiple backslashes in the nested JSON builder. ([#1285](https://github.com/httpie/httpie/issues/1285))
 - Fixed displaying of status code without a status message on non-`auto` themes. ([#1300](https://github.com/httpie/httpie/issues/1300))
+- Fixed redundant issuance of stdin detection warnings on some rare cases due to underlying implementation. ([#1303](https://github.com/httpie/httpie/pull/1303)) 
 - Improved regulation of top-level arrays. ([#1292](https://github.com/httpie/httpie/commit/225dccb2186f14f871695b6c4e0bfbcdb2e3aa28))
 - Double `--quiet` flags will now suppress all python level warnings. ([#1271](https://github.com/httpie/httpie/issues/1271))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - Fixed escaping of integer indexes with multiple backslashes in the nested JSON builder. ([#1285](https://github.com/httpie/httpie/issues/1285))
 - Fixed displaying of status code without a status message on non-`auto` themes. ([#1300](https://github.com/httpie/httpie/issues/1300))
-- Fixed redundant issuance of stdin detection warnings on some rare cases due to underlying implementation. ([#1303](https://github.com/httpie/httpie/pull/1303)) 
+- Fixed redundant issuance of stdin detection warnings on some rare cases due to underlying implementation. ([#1303](https://github.com/httpie/httpie/pull/1303))
 - Improved regulation of top-level arrays. ([#1292](https://github.com/httpie/httpie/commit/225dccb2186f14f871695b6c4e0bfbcdb2e3aa28))
 - Double `--quiet` flags will now suppress all python level warnings. ([#1271](https://github.com/httpie/httpie/issues/1271))
 

--- a/httpie/uploads.py
+++ b/httpie/uploads.py
@@ -94,7 +94,7 @@ def is_stdin(file: IO) -> bool:
         return file_no == sys.stdin.fileno()
 
 
-READ_THRESHOLD = float(os.getenv("HTTPIE_STDIN_READ_WARN_THRESHOLD", 10.0))
+READ_THRESHOLD = float(os.getenv('HTTPIE_STDIN_READ_WARN_THRESHOLD', 10.0))
 
 
 def observe_stdin_for_data_thread(env: Environment, file: IO, read_event: threading.Event) -> None:


### PR DESCRIPTION
This patch fixes a race happening between 2 IO bound operations:
- `read(2)` with `sys.stdin`
- `select(2)` with `sys.stdin`

![image](https://user-images.githubusercontent.com/47358913/156065434-f7fd5fe1-8f59-420d-ad86-6db283873a42.png)

`select(2)` is a function that takes files and tells when they are ready to be processed (read/written etc.). It is used for concurrently dealing with multiple sockets (e.g you have multiple open connections, and with `select(2)` you can check which one of those connections have some data to be processed). In HTTPie however, we used it to detect whether there is any incoming data to the `sys.stdin`, so that when there is no data we could issue a warning.

The problem is that, the initial version of this code unknowlingly created a race between the `select.select` call:
https://github.com/httpie/httpie/blob/30cd862fc0e173698fc17487c4b96d8f64b701ea/httpie/uploads.py#L98-L110

and the `file.read()` call:
https://github.com/httpie/httpie/blob/30cd862fc0e173698fc17487c4b96d8f64b701ea/httpie/uploads.py#L124-L132

Both of these functions are blocking, and we ran them concurrently to get away from that issue. But since Python has a GIL, when you run multiple threads together, depending on the CPU-related activity and some other details it switches between them on certain intervals. (green arrows indicate the interpreter given the execution to the Main Thread, red indicate it is given to Observer Thread)

![image](https://user-images.githubusercontent.com/47358913/156067165-220ff8dd-df31-4059-a6f5-1beb7f0617b9.png)

So to put it simply, we used to run the `read()` and the `select()` at the same time and whichever gets choosen to be executed at that time would win. If it was `select()`, we'd get the correct result (about whether there is any data or not) and if it was `read()` we'd always get the wrong result (no incomiong data). This caused to intermittent / random failure. From what I understood this problem happens randomly (and in a OS-dependant way, because of the underlying thread scheduler), and there is no fair way of testing it (except manually). 

The race has been solved by moving the `select(2)` out of the thread (as a guard) and using `threading.Event`s as indicators about whether we've seen any data or not. 