### PR TITLE
Fix bug #662 - cookies not being maintained correctly over session involving redirects+set-cookie - need to save cookie domain in sessions file

### DIFF
--- a/httpie/sessions.py
+++ b/httpie/sessions.py
@@ -113,7 +113,7 @@ class Session(BaseConfigDict):
     @cookies.setter
     def cookies(self, jar: RequestsCookieJar):
         # <https://docs.python.org/3/library/cookielib.html#cookie-objects>
-        stored_attrs = ['value', 'path', 'secure', 'expires']
+        stored_attrs = ['value', 'domain', 'path', 'secure', 'expires']
         self['cookies'] = {}
         for cookie in jar:
             self['cookies'][cookie.name] = {


### PR DESCRIPTION
Observed problems using --follow with --session, that on resuming using the saved session but expired authentication cookies stored in the session, httpie was generating duplicated cookies - saving the domain in the session file resolved this.