### PR TITLE
Change partial upgrade to full upgrade in Arch Linux installation documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -205,12 +205,12 @@ Also works for other Arch-derived distributions like ArcoLinux, EndeavourOS, Art
 
 ```bash
 # Install httpie
-$ pacman -Sy httpie
+$ pacman -Syu httpie
 ```
 
 ```bash
 # Upgrade httpie
-$ pacman -Syu httpie
+$ pacman -Syu
 ```
 
 ### FreeBSD

--- a/docs/installation/methods.yml
+++ b/docs/installation/methods.yml
@@ -106,9 +106,9 @@ tools:
       package: https://archlinux.org/packages/community/any/httpie/
     commands:
       install:
-        - pacman -Sy httpie
-      upgrade:
         - pacman -Syu httpie
+      upgrade:
+        - pacman -Syu
 
   pkg:
     title: FreshPorts


### PR DESCRIPTION
Addresses problem described in #1305 changing command from partial upgrade to full upgrade on installation, which should be both safe and painless for new into rolling-release model (`-S` alone could cause a stream of **404** responses due to old versions not being stored)

Additionally removed argument from upgrade command, since `-Syu` alone will update package that's already installed.