### PR TITLE
Don't send `Content-Length` for `OPTIONS` requests when there is no data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This document records all notable changes to [HTTPie](https://httpie.io).
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.1.1.dev0](https://github.com/httpie/httpie/compare/3.1.0...HEAD) (Unreleased)
+
+- Fixed redundant creation of `Content-Length` header on `OPTIONS` requests. ([#1310](https://github.com/httpie/httpie/issues/1310))
+
 ## [3.1.0](https://github.com/httpie/httpie/compare/3.0.2...3.1.0) (2022-03-08)
 
 - **SECURITY** Fixed the [vulnerability](https://github.com/httpie/httpie/security/advisories/GHSA-9w4w-cpc8-h2fq) that caused exposure of cookies on redirects to third party hosts. ([#1312](https://github.com/httpie/httpie/pull/1312))

--- a/httpie/__init__.py
+++ b/httpie/__init__.py
@@ -3,6 +3,6 @@ HTTPie: modern, user-friendly command-line HTTP client for the API era.
 
 """
 
-__version__ = '3.1.0'
+__version__ = '3.1.1.dev0'
 __author__ = 'Jakub Roztocil'
 __licence__ = 'BSD'

--- a/httpie/cli/constants.py
+++ b/httpie/cli/constants.py
@@ -9,6 +9,7 @@ URL_SCHEME_RE = re.compile(r'^[a-z][a-z0-9.+-]*://', re.IGNORECASE)
 
 HTTP_POST = 'POST'
 HTTP_GET = 'GET'
+HTTP_OPTIONS = 'OPTIONS'
 
 # Various separators used in args
 SEPARATOR_HEADER = ':'

--- a/tests/test_httpie.py
+++ b/tests/test_httpie.py
@@ -324,3 +324,41 @@ def test_json_input_preserve_order(httpbin_both):
     assert HTTP_OK in r
     assert r.json['data'] == \
         '{"order": {"map": {"1": "first", "2": "second"}}}'
+
+
+@pytest.mark.parametrize('extra_args, expected_content_length', [
+    (
+        ['Content-Length:0'],
+        '0'
+    ),
+    (
+        ['Content-Length:xxx'],
+        'xxx',
+    ),
+    (
+        ['--raw=data'],
+        '4'
+    ),
+    (
+        ['query[param]=something'],
+        '33'
+    )
+])
+def test_options_content_length_preservation(httpbin, extra_args, expected_content_length):
+    r = http(
+        '--offline',
+        'OPTIONS',
+        httpbin + '/anything',
+        *extra_args
+    )
+    assert f'Content-Length: {expected_content_length}' in r
+
+
+@pytest.mark.parametrize('method', ['options', 'Options', 'OPTIONS'])
+def test_options_dropping_redundant_content_length(httpbin, method):
+    r = http(
+        '--offline',
+        method,
+        httpbin + '/anything'
+    )
+    assert 'Content-Length' not in r


### PR DESCRIPTION
Fixes #1310.