### PR TITLE
Rich progress bars.

### DIFF
--- a/httpie/context.py
+++ b/httpie/context.py
@@ -18,7 +18,7 @@ from .config import DEFAULT_CONFIG_DIR, Config, ConfigFileError
 from .encoding import UTF8
 
 from .utils import repr_dict
-from httpie.output.ui import palette
+from httpie.output.ui import rich_palette as palette
 
 if TYPE_CHECKING:
     from rich.console import Console
@@ -58,6 +58,10 @@ class Environment:
     stderr_isatty: bool = stderr.isatty()
     colors = 256
     program_name: str = 'http'
+
+    # Whether to show progress bars / status spinners etc.
+    show_displays: bool = True
+
     if not is_windows:
         if curses:
             try:
@@ -181,8 +185,15 @@ class Environment:
         if style in palette.STYLE_SHADES:
             shade = palette.STYLE_SHADES[style]
             theme.update({
-                color: Style(color=palette.get_color(color, shade), bold=True)
-                for color in palette.COLOR_PALETTE
+                color: Style(
+                    color=palette.get_color(
+                        color,
+                        shade,
+                        palette=palette.RICH_THEME_PALETTE
+                    ),
+                    bold=True
+                )
+                for color in palette.RICH_THEME_PALETTE
             })
 
         # Rich infers the rest of the knowledge (e.g encoding)

--- a/httpie/core.py
+++ b/httpie/core.py
@@ -195,7 +195,7 @@ def program(args: argparse.Namespace, env: Environment) -> ExitStatus:
     try:
         if args.download:
             args.follow = True  # --download implies --follow.
-            downloader = Downloader(output_file=args.output_file, progress_file=env.stderr, resume=args.download_resume)
+            downloader = Downloader(env, output_file=args.output_file, resume=args.download_resume)
             downloader.pre_request(args.headers)
         messages = collect_messages(env, args=args,
                                     request_body_read_callback=request_body_read_callback)

--- a/httpie/output/ui/palette.py
+++ b/httpie/output/ui/palette.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Optional
 
 AUTO_STYLE = 'auto'  # Follows terminal ANSI color styles
 STYLE_PIE = 'pie'
@@ -160,11 +160,16 @@ SHADES = [
 ]
 
 
-def get_color(color: str, shade: str) -> Optional[str]:
-    if color not in COLOR_PALETTE:
+def get_color(
+    color: str,
+    shade: str,
+    *,
+    palette: Dict[str, Dict[str, str]] = COLOR_PALETTE
+) -> Optional[str]:
+    if color not in palette:
         return None
 
-    color_code = COLOR_PALETTE[color]
+    color_code = palette[color]
     if isinstance(color_code, dict) and shade in color_code:
         return color_code[shade]
     else:

--- a/httpie/output/ui/rich_palette.py
+++ b/httpie/output/ui/rich_palette.py
@@ -1,0 +1,22 @@
+from httpie.output.ui.palette import * # noqa
+
+# Rich-specific color code declarations
+# https://github.com/Textualize/rich/blob/fcd684dd3a482977cab620e71ccaebb94bf13ac9/rich/default_styles.py#L5
+CUSTOM_STYLES = {
+    'progress.description': 'white',
+    'progress.data.speed': 'green',
+    'progress.percentage': 'aqua',
+    'progress.download': 'aqua',
+    'progress.remaining': 'orange',
+    'bar.complete': 'purple',
+    'bar.finished': 'green',
+    'bar.pulse': 'purple',
+}
+
+RICH_THEME_PALETTE = COLOR_PALETTE.copy() # noqa
+RICH_THEME_PALETTE.update(
+    {
+        custom_style: RICH_THEME_PALETTE[color]
+        for custom_style, color in CUSTOM_STYLES.items()
+    }
+)

--- a/httpie/output/ui/rich_progress.py
+++ b/httpie/output/ui/rich_progress.py
@@ -1,0 +1,93 @@
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+from httpie.context import Environment
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+
+@dataclass
+class BaseDisplay:
+    env: Environment
+
+    def start(
+        self, *, total: Optional[float], at: float, description: str
+    ) -> None:
+        ...
+
+    def update(self, steps: float) -> None:
+        ...
+
+    def stop(self) -> None:
+        ...
+
+    @property
+    def console(self) -> 'Console':
+        """Returns the default console to be used with displays (stderr)."""
+        return self.env.rich_error_console
+
+
+class DummyDisplay(BaseDisplay):
+    """
+    A dummy display object to be used when the progress bars,
+    spinners etc. are disabled globally (or during tests).
+    """
+
+
+class StatusDisplay(BaseDisplay):
+    def start(
+        self, *, total: Optional[float], at: float, description: str
+    ) -> None:
+        self.observed = at
+        self.description = f'[white]{description}[/white]'
+
+        self.status = self.console.status(self.description, spinner='aesthetic')
+        self.status.start()
+
+    def update(self, steps: float) -> None:
+        from rich import filesize
+
+        self.observed += steps
+
+        observed_units = filesize.decimal(self.observed, separator='/? ')
+        self.status.update(status=f'{self.description} [progress.download]{observed_units}[/progress.download]')
+
+    def stop(self) -> None:
+        self.status.stop()
+
+
+class ProgressDisplay(BaseDisplay):
+    def start(
+        self, *, total: Optional[float], at: float, description: str
+    ) -> None:
+        from rich.progress import (
+            Progress,
+            BarColumn,
+            DownloadColumn,
+            TimeRemainingColumn,
+            TransferSpeedColumn,
+        )
+
+        assert total is not None
+        self.progress_bar = Progress(
+            '[progress.description]{task.description}',
+            BarColumn(),
+            '[progress.percentage]{task.percentage:>3.0f}%',
+            '(',
+            DownloadColumn(),
+            ')',
+            TimeRemainingColumn(),
+            TransferSpeedColumn(),
+            console=self.console,
+        )
+        self.progress_bar.start()
+        self.transfer_task = self.progress_bar.add_task(
+            description, completed=at, total=total
+        )
+
+    def update(self, steps: float) -> None:
+        self.progress_bar.advance(self.transfer_task, steps)
+
+    def stop(self) -> None:
+        self.progress_bar.stop()

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -125,16 +125,14 @@ class TestDownloads:
     def test_actual_download(self, httpbin_both, httpbin):
         robots_txt = '/robots.txt'
         body = urlopen(httpbin + robots_txt).read().decode()
-        env = MockEnvironment(stdin_isatty=True, stdout_isatty=False)
+        env = MockEnvironment(stdin_isatty=True, stdout_isatty=False, show_displays=True)
         r = http('--download', httpbin_both.url + robots_txt, env=env)
         assert 'Downloading' in r.stderr
-        assert '[K' in r.stderr
-        assert 'Done' in r.stderr
         assert body == r
 
-    def test_download_with_Content_Length(self, httpbin_both):
+    def test_download_with_Content_Length(self, mock_env, httpbin_both):
         with open(os.devnull, 'w') as devnull:
-            downloader = Downloader(output_file=devnull, progress_file=devnull)
+            downloader = Downloader(mock_env, output_file=devnull)
             downloader.start(
                 initial_url='/',
                 final_response=Response(
@@ -148,11 +146,10 @@ class TestDownloads:
             downloader.chunk_downloaded(b'12345')
             downloader.finish()
             assert not downloader.interrupted
-            downloader._progress_reporter.join()
 
-    def test_download_no_Content_Length(self, httpbin_both):
+    def test_download_no_Content_Length(self, mock_env, httpbin_both):
         with open(os.devnull, 'w') as devnull:
-            downloader = Downloader(output_file=devnull, progress_file=devnull)
+            downloader = Downloader(mock_env, output_file=devnull)
             downloader.start(
                 final_response=Response(url=httpbin_both.url + '/'),
                 initial_url='/'
@@ -161,15 +158,14 @@ class TestDownloads:
             downloader.chunk_downloaded(b'12345')
             downloader.finish()
             assert not downloader.interrupted
-            downloader._progress_reporter.join()
 
-    def test_download_output_from_content_disposition(self, httpbin_both):
-        with tempfile.TemporaryDirectory() as tmp_dirname, open(os.devnull, 'w') as devnull:
+    def test_download_output_from_content_disposition(self, mock_env, httpbin_both):
+        with tempfile.TemporaryDirectory() as tmp_dirname:
             orig_cwd = os.getcwd()
             os.chdir(tmp_dirname)
             try:
                 assert not os.path.isfile('filename.bin')
-                downloader = Downloader(progress_file=devnull)
+                downloader = Downloader(mock_env)
                 downloader.start(
                     final_response=Response(
                         url=httpbin_both.url + '/',
@@ -184,7 +180,6 @@ class TestDownloads:
                 downloader.finish()
                 downloader.failed()  # Stop the reporter
                 assert not downloader.interrupted
-                downloader._progress_reporter.join()
 
                 # TODO: Auto-close the file in that case?
                 downloader._output_file.close()
@@ -192,9 +187,9 @@ class TestDownloads:
             finally:
                 os.chdir(orig_cwd)
 
-    def test_download_interrupted(self, httpbin_both):
+    def test_download_interrupted(self, mock_env, httpbin_both):
         with open(os.devnull, 'w') as devnull:
-            downloader = Downloader(output_file=devnull, progress_file=devnull)
+            downloader = Downloader(mock_env, output_file=devnull)
             downloader.start(
                 final_response=Response(
                     url=httpbin_both.url + '/',
@@ -205,17 +200,16 @@ class TestDownloads:
             downloader.chunk_downloaded(b'1234')
             downloader.finish()
             assert downloader.interrupted
-            downloader._progress_reporter.join()
 
-    def test_download_resumed(self, httpbin_both):
+    def test_download_resumed(self, mock_env, httpbin_both):
         with tempfile.TemporaryDirectory() as tmp_dirname:
             file = os.path.join(tmp_dirname, 'file.bin')
             with open(file, 'a'):
                 pass
 
-            with open(os.devnull, 'w') as devnull, open(file, 'a+b') as output_file:
+            with open(file, 'a+b') as output_file:
                 # Start and interrupt the transfer after 3 bytes written
-                downloader = Downloader(output_file=output_file, progress_file=devnull)
+                downloader = Downloader(mock_env, output_file=output_file)
                 downloader.start(
                     final_response=Response(
                         url=httpbin_both.url + '/',
@@ -227,15 +221,14 @@ class TestDownloads:
                 downloader.finish()
                 downloader.failed()
                 assert downloader.interrupted
-                downloader._progress_reporter.join()
 
             # Write bytes
             with open(file, 'wb') as fh:
                 fh.write(b'123')
 
-            with open(os.devnull, 'w') as devnull, open(file, 'a+b') as output_file:
+            with open(file, 'a+b') as output_file:
                 # Resume the transfer
-                downloader = Downloader(output_file=output_file, progress_file=devnull, resume=True)
+                downloader = Downloader(mock_env, output_file=output_file, resume=True)
 
                 # Ensure `pre_request()` is working as expected too
                 headers = {}
@@ -253,7 +246,6 @@ class TestDownloads:
                 )
                 downloader.chunk_downloaded(b'45')
                 downloader.finish()
-                downloader._progress_reporter.join()
 
     def test_download_with_redirect_original_url_used_for_filename(self, httpbin):
         # Redirect from `/redirect/1` to `/get`.

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -124,6 +124,7 @@ class MockEnvironment(Environment):
     stdin_isatty = True
     stdout_isatty = True
     is_windows = False
+    show_displays = False
 
     def __init__(self, create_temp_config_dir=True, **kwargs):
         self._encoder = Encoder()


### PR DESCRIPTION
This PR moves our own progress bar system to rich. More specifically, we now have 3 different progress bars internally (all powered by rich):

1. The regular progress bar. It is used for the most of scenerios. 
[![asciicast](https://asciinema.org/a/9jRH7lucOIcXWpvB4qPUpKgZN.svg)](https://asciinema.org/a/9jRH7lucOIcXWpvB4qPUpKgZN)

2. A 'status' object, to be used when the total size (e.g `Content-Length`) is missing from the pre-request. This is a distinct object, since rich does not support progress bars whom total size is unknown.
[![asciicast](https://asciinema.org/a/ToRABuf5Ha1K5Y8GuJaZLbHaH.svg)](https://asciinema.org/a/ToRABuf5Ha1K5Y8GuJaZLbHaH)

3. A dummy progress bar, to be used at tests. 

Since we have 3 of them, I created a unified interface so that in the code (under `DownloadStatus`) we don't need to manually handle each object. The unified interface has `start()`/`update()`/`stop()` which seem to be sufficient for all tasks.