### PR TITLE
Pin the date for man pages.

### DIFF
--- a/extras/man/http.1
+++ b/extras/man/http.1
@@ -1,4 +1,4 @@
-.TH http 1 "2022-03-14" "HTTPie 3.1.0" "HTTPie Manual"
+.TH http 1 "2022-03-08" "HTTPie 3.1.0" "HTTPie Manual"
 .SH NAME
 http
 .SH SYNOPSIS

--- a/extras/man/https.1
+++ b/extras/man/https.1
@@ -1,4 +1,4 @@
-.TH https 1 "2022-03-14" "HTTPie 3.1.0" "HTTPie Manual"
+.TH https 1 "2022-03-08" "HTTPie 3.1.0" "HTTPie Manual"
 .SH NAME
 https
 .SH SYNOPSIS

--- a/extras/scripts/generate_man_pages.py
+++ b/extras/scripts/generate_man_pages.py
@@ -11,7 +11,6 @@ from httpie.output.ui.rich_help import to_usage
 from httpie.output.ui.rich_utils import render_as_string
 from httpie.utils import split
 
-LAST_EDIT_DATE = str(datetime.date.today())
 
 # Escape certain characters so they are rendered properly on
 # all terminals.
@@ -88,7 +87,7 @@ def to_man_page(program_name: str, spec: ParserSpec) -> str:
         full_name='HTTPie',
         program_name=program_name,
         program_version=httpie.__version__,
-        last_edit_date=LAST_EDIT_DATE,
+        last_edit_date=httpie.__date__,
     )
     builder.set_name(program_name)
 

--- a/httpie/__init__.py
+++ b/httpie/__init__.py
@@ -4,5 +4,6 @@ HTTPie: modern, user-friendly command-line HTTP client for the API era.
 """
 
 __version__ = '3.1.0'
+__date__ = '2022-03-08'
 __author__ = 'Jakub Roztocil'
 __licence__ = 'BSD'


### PR DESCRIPTION
The date for the man pages should be the same with the release date. This also improved reproducibility on the CI.