### PR TITLE
Use `pager` and `man` on `--manual` when applicable

### DIFF
--- a/httpie/cli/argparser.py
+++ b/httpie/cli/argparser.py
@@ -563,8 +563,14 @@ class HTTPieArgumentParser(BaseHTTPieArgumentParser):
 
         if man_pages.is_available(self.env.program_name):
             man_pages.display_for(self.env, self.env.program_name)
-        else:
-            super().print_help()
+            return None
+
+        text = self.format_help()
+        with self.env.rich_console.pager():
+            self.env.rich_console.print(
+                text,
+                highlight=False
+            )
 
     def print_help(self):
         from httpie.output.ui import rich_help

--- a/httpie/cli/argparser.py
+++ b/httpie/cli/argparser.py
@@ -559,7 +559,12 @@ class HTTPieArgumentParser(BaseHTTPieArgumentParser):
         self.args.format_options = parsed_options
 
     def print_manual(self):
-        return super().print_help()
+        from httpie.output.ui import man_pages
+
+        if man_pages.is_available(self.env.program_name):
+            man_pages.display_for(self.env, self.env.program_name)
+        else:
+            super().print_help()
 
     def print_help(self):
         from httpie.output.ui import rich_help

--- a/httpie/output/ui/man_pages.py
+++ b/httpie/output/ui/man_pages.py
@@ -1,0 +1,33 @@
+"""Logic for checking and displaying man pages."""
+
+import subprocess
+import os
+from httpie.context import Environment
+
+MAN_COMMAND = 'man'
+
+
+def is_available(program: str) -> bool:
+    """Check whether HTTPie's man pages are available in this system."""
+
+    if os.system == 'nt':
+        return False
+
+    process = subprocess.run(
+        [MAN_COMMAND, program],
+        shell=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL
+    )
+    return process.returncode == 0
+
+
+def display_for(env: Environment, program: str) -> None:
+    """Display the man page for the given command (http/https)."""
+
+    subprocess.run(
+        [MAN_COMMAND, program],
+        stdout=env.stdout,
+        stderr=env.stderr
+    )
+


### PR DESCRIPTION
- On systems where `man` is available and `httpie`'s man pages are installed, we'll launch `man http/https` on `--manual`
- For other systems, we'll render the argparse manual text and dump into a pager (if there is a pager).
- And for other systems (e.g there is no less/more), we'll simply print it to stdout.