### PR TITLE
Ping werkzeug to <2.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ tests_require = [
     'pytest-httpbin>=0.0.6',
     'pytest-lazy-fixture>=0.0.6',
     'responses',
+    'werkzeug<2.1.0'
 ]
 dev_require = [
     *tests_require,


### PR DESCRIPTION
The new release breaks `pytest-httpbin`.