### PR TITLE
Generate CLI spec from HTTPie & Man Page Hook

### DIFF
--- a/extras/man/http.1
+++ b/extras/man/http.1
@@ -1,4 +1,4 @@
-.TH http 1 "2022-03-08" "HTTPie 3.1.0" "HTTPie Manual"
+.TH http 1 "2022-03-08" "HTTPie 3.1.1.dev0" "HTTPie Manual"
 .SH NAME
 http
 .SH SYNOPSIS

--- a/extras/man/httpie.1
+++ b/extras/man/httpie.1
@@ -12,14 +12,14 @@ Be aware that you might be looking for http/https commands for sending
 HTTP requests. This command is only available for managing the HTTTPie
 plugins and the configuration around it.
 
-.SH export-args
+.SH httpie cli export-args
 Export available options for the CLI
 .IP "\fB\,-f\/\fR, \fB\,--format\/\fR"
 
 
 
 .PP
-.SH upgrade
+.SH httpie cli sessions upgrade
 Upgrade the given HTTPie session with the latest layout. A list of changes between different session versions can be found in the official documentation.
 .IP "\fB\,HOSTNAME\/\fR"
 
@@ -34,58 +34,58 @@ The name or the path for the session that will be upgraded.
 Bind domainless cookies to the host that session belongs.
 
 .PP
-.SH upgrade-all
+.SH httpie cli sessions upgrade-all
 Upgrade all named sessions with the latest layout. A list of changes between different session versions can be found in the official documentation.
 .IP "\fB\,--bind-cookies\/\fR"
 
 Bind domainless cookies to the host that session belongs.
 
 .PP
-.SH install
+.SH httpie cli plugins install
 Install the given targets from PyPI or from a local paths.
 .IP "\fB\,TARGET\/\fR"
 
 targets to install
 
 .PP
-.SH upgrade
+.SH httpie cli plugins upgrade
 Upgrade the given plugins
 .IP "\fB\,TARGET\/\fR"
 
 targets to upgrade
 
 .PP
-.SH uninstall
+.SH httpie cli plugins uninstall
 Uninstall the given HTTPie plugins.
 .IP "\fB\,TARGET\/\fR"
 
 targets to install
 
 .PP
-.SH list
+.SH httpie cli plugins list
 List all installed HTTPie plugins.
 .PP
-.SH install
+.SH httpie plugins install
 Install the given targets from PyPI or from a local paths.
 .IP "\fB\,TARGET\/\fR"
 
 targets to install
 
 .PP
-.SH upgrade
+.SH httpie plugins upgrade
 Upgrade the given plugins
 .IP "\fB\,TARGET\/\fR"
 
 targets to upgrade
 
 .PP
-.SH uninstall
+.SH httpie plugins uninstall
 Uninstall the given HTTPie plugins.
 .IP "\fB\,TARGET\/\fR"
 
 targets to install
 
 .PP
-.SH list
+.SH httpie plugins list
 List all installed HTTPie plugins.
 .PP

--- a/extras/man/httpie.1
+++ b/extras/man/httpie.1
@@ -1,0 +1,91 @@
+.TH httpie 1 "2022-03-08" "HTTPie 3.1.1.dev0" "HTTPie Manual"
+.SH NAME
+httpie
+.SH SYNOPSIS
+httpie HOSTNAME SESSION_NAME_OR_PATH TARGET TARGET TARGET TARGET TARGET TARGET
+
+.SH DESCRIPTION
+
+Managing interface for the HTTPie itself. <https://httpie.io/docs#manager>
+
+Be aware that you might be looking for http/https commands for sending
+HTTP requests. This command is only available for managing the HTTTPie
+plugins and the configuration around it.
+
+.SH export-args
+Export available options for the CLI
+.IP "\fB\,-f\/\fR, \fB\,--format\/\fR"
+
+
+
+.PP
+.SH upgrade
+Upgrade the given HTTPie session with the latest layout. A list of changes between different session versions can be found in the official documentation.
+.IP "\fB\,HOSTNAME\/\fR"
+
+The host this session belongs.
+
+.IP "\fB\,SESSION_NAME_OR_PATH\/\fR"
+
+The name or the path for the session that will be upgraded.
+
+.IP "\fB\,--bind-cookies\/\fR"
+
+Bind domainless cookies to the host that session belongs.
+
+.PP
+.SH upgrade-all
+Upgrade all named sessions with the latest layout. A list of changes between different session versions can be found in the official documentation.
+.IP "\fB\,--bind-cookies\/\fR"
+
+Bind domainless cookies to the host that session belongs.
+
+.PP
+.SH install
+Install the given targets from PyPI or from a local paths.
+.IP "\fB\,TARGET\/\fR"
+
+targets to install
+
+.PP
+.SH upgrade
+Upgrade the given plugins
+.IP "\fB\,TARGET\/\fR"
+
+targets to upgrade
+
+.PP
+.SH uninstall
+Uninstall the given HTTPie plugins.
+.IP "\fB\,TARGET\/\fR"
+
+targets to install
+
+.PP
+.SH list
+List all installed HTTPie plugins.
+.PP
+.SH install
+Install the given targets from PyPI or from a local paths.
+.IP "\fB\,TARGET\/\fR"
+
+targets to install
+
+.PP
+.SH upgrade
+Upgrade the given plugins
+.IP "\fB\,TARGET\/\fR"
+
+targets to upgrade
+
+.PP
+.SH uninstall
+Uninstall the given HTTPie plugins.
+.IP "\fB\,TARGET\/\fR"
+
+targets to install
+
+.PP
+.SH list
+List all installed HTTPie plugins.
+.PP

--- a/extras/man/https.1
+++ b/extras/man/https.1
@@ -1,4 +1,4 @@
-.TH https 1 "2022-03-08" "HTTPie 3.1.0" "HTTPie Manual"
+.TH https 1 "2022-03-08" "HTTPie 3.1.1.dev0" "HTTPie Manual"
 .SH NAME
 https
 .SH SYNOPSIS

--- a/extras/scripts/generate_man_pages.py
+++ b/extras/scripts/generate_man_pages.py
@@ -1,13 +1,12 @@
-import textwrap
-import datetime
 import re
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Optional, Iterator, Iterable
 
 import httpie
-from httpie.cli.definition import options
-from httpie.cli.options import Argument, ParserSpec, Qualifiers
+from httpie.cli.definition import options as core_options
+from httpie.cli.options import ParserSpec
+from httpie.manager.cli import options as manager_options
 from httpie.output.ui.rich_help import OptionsHighlighter, to_usage
 from httpie.output.ui.rich_utils import render_as_string
 from httpie.utils import split
@@ -143,9 +142,14 @@ def to_man_page(program_name: str, spec: ParserSpec) -> str:
 
 
 def main() -> None:
-    for program_name in ['http', 'https']:
+    for program_name, spec in [
+        ('http', core_options),
+        ('https', core_options),
+        ('httpie', manager_options),
+    ]:
         with open((MAN_PAGE_PATH / program_name).with_suffix('.1'), 'w') as stream:
-            stream.write(to_man_page(program_name, options))
+            stream.write(to_man_page(program_name, spec))
+
 
 
 if __name__ == '__main__':

--- a/httpie/cli/options.py
+++ b/httpie/cli/options.py
@@ -12,6 +12,7 @@ from httpie.cli.utils import Manual, LazyChoices
 class Qualifiers(Enum):
     OPTIONAL = auto()
     ZERO_OR_MORE = auto()
+    ONE_OR_MORE = auto()
     SUPPRESS = auto()
 
 
@@ -193,6 +194,7 @@ ARGPARSE_QUALIFIER_MAP = {
     Qualifiers.OPTIONAL: argparse.OPTIONAL,
     Qualifiers.SUPPRESS: argparse.SUPPRESS,
     Qualifiers.ZERO_OR_MORE: argparse.ZERO_OR_MORE,
+    Qualifiers.ONE_OR_MORE: argparse.ONE_OR_MORE
 }
 ARGPARSE_IGNORE_KEYS = ('short_help', 'nested_options')
 
@@ -237,9 +239,19 @@ JSON_DIRECT_MIRROR_OPTIONS = (
 JSON_QUALIFIER_TO_OPTIONS = {
     Qualifiers.OPTIONAL: {'is_optional': True},
     Qualifiers.ZERO_OR_MORE: {'is_optional': True, 'is_variadic': True},
+    Qualifiers.ONE_OR_MORE: {'is_optional': False, 'is_variadic': True},
     Qualifiers.SUPPRESS: {}
 }
 
 
 def to_data(abstract_options: ParserSpec) -> Dict[str, Any]:
     return {'version': PARSER_SPEC_VERSION, 'spec': abstract_options.serialize()}
+
+
+def parser_to_parser_spec(parser: argparse.ArgumentParser) -> ParserSpec:
+    """Take an existing argparse parser, and create a spec from it."""
+    return ParserSpec(
+        program=parser.prog,
+        description=parser.description,
+        epilog=parser.epilog
+    )

--- a/httpie/manager/cli.py
+++ b/httpie/manager/cli.py
@@ -1,6 +1,6 @@
 from textwrap import dedent
 from httpie.cli.argparser import HTTPieManagerArgumentParser
-from httpie.cli.options import Qualifiers, ARGPARSE_QUALIFIER_MAP, map_qualifiers, parser_to_parser_spec, to_data
+from httpie.cli.options import Qualifiers, ARGPARSE_QUALIFIER_MAP, map_qualifiers, parser_to_parser_spec
 from httpie import __version__
 
 CLI_SESSION_UPGRADE_FLAGS = [
@@ -114,7 +114,7 @@ def generate_subparsers(root, parent_parser, definitions, spec):
             generate_subparsers(root, command_parser, properties, spec)
             continue
 
-        group = spec.add_group(command, description=descr)
+        group = spec.add_group(parent_parser.prog + ' ' + command, description=descr)
         for argument in properties:
             argument = argument.copy()
             flags = argument.pop('flags', [])

--- a/httpie/manager/cli.py
+++ b/httpie/manager/cli.py
@@ -1,5 +1,6 @@
 from textwrap import dedent
 from httpie.cli.argparser import HTTPieManagerArgumentParser
+from httpie.cli.options import Qualifiers, ARGPARSE_QUALIFIER_MAP, map_qualifiers, parser_to_parser_spec, to_data
 from httpie import __version__
 
 CLI_SESSION_UPGRADE_FLAGS = [
@@ -58,7 +59,8 @@ COMMANDS['plugins'] = COMMANDS['cli']['plugins'] = {
         'or from a local paths.',
         {
             'dest': 'targets',
-            'nargs': '+',
+            'metavar': 'TARGET',
+            'nargs': Qualifiers.ONE_OR_MORE,
             'help': 'targets to install'
         }
     ],
@@ -66,7 +68,8 @@ COMMANDS['plugins'] = COMMANDS['cli']['plugins'] = {
         'Upgrade the given plugins',
         {
             'dest': 'targets',
-            'nargs': '+',
+            'metavar': 'TARGET',
+            'nargs': Qualifiers.ONE_OR_MORE,
             'help': 'targets to upgrade'
         }
     ],
@@ -74,7 +77,8 @@ COMMANDS['plugins'] = COMMANDS['cli']['plugins'] = {
         'Uninstall the given HTTPie plugins.',
         {
             'dest': 'targets',
-            'nargs': '+',
+            'metavar': 'TARGET',
+            'nargs': Qualifiers.ONE_OR_MORE,
             'help': 'targets to install'
         }
     ],
@@ -94,7 +98,7 @@ def missing_subcommand(*args) -> str:
     return f'Please specify one of these: {subcommands}'
 
 
-def generate_subparsers(root, parent_parser, definitions):
+def generate_subparsers(root, parent_parser, definitions, spec):
     action_dest = '_'.join(parent_parser.prog.split()[1:] + ['action'])
     actions = parent_parser.add_subparsers(
         dest=action_dest
@@ -107,13 +111,15 @@ def generate_subparsers(root, parent_parser, definitions):
         command_parser = actions.add_parser(command, description=descr)
         command_parser.root = root
         if is_subparser:
-            generate_subparsers(root, command_parser, properties)
+            generate_subparsers(root, command_parser, properties, spec)
             continue
 
+        group = spec.add_group(command, description=descr)
         for argument in properties:
             argument = argument.copy()
             flags = argument.pop('flags', [])
-            command_parser.add_argument(*flags, **argument)
+            command_parser.add_argument(*flags, **map_qualifiers(argument, ARGPARSE_QUALIFIER_MAP))
+            group.add_argument(*flags, **argument)
 
 
 parser = HTTPieManagerArgumentParser(
@@ -160,4 +166,5 @@ parser.add_argument(
     '''
 )
 
-generate_subparsers(parser, parser, COMMANDS)
+options = parser_to_parser_spec(parser)
+generate_subparsers(parser, parser, COMMANDS, options)


### PR DESCRIPTION
Now `httpie` command also generates a `ParserSpec`, and it is hooked against the man page generation script which will automatically create a man page for it.