### PR TITLE
Docs/ Installation with Pacman (Arch Linux)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -204,13 +204,8 @@ $ yum upgrade httpie
 Also works for other Arch-derived distributions like ArcoLinux, EndeavourOS, Artix Linux, etc.
 
 ```bash
-# Install httpie
-$ pacman -Syu httpie
-```
-
-```bash
-# Upgrade httpie
-$ pacman -Syu
+# Install (or upgrade) httpie
+$ pacman -S httpie
 ```
 
 ### FreeBSD

--- a/docs/README.md
+++ b/docs/README.md
@@ -205,7 +205,7 @@ Also works for other Arch-derived distributions like ArcoLinux, EndeavourOS, Art
 
 ```bash
 # Install (or upgrade) httpie
-$ pacman -S httpie
+$ sudo pacman -S httpie
 ```
 
 ### FreeBSD


### PR DESCRIPTION
Hey guys,
Current documentation is instructing to upgrade all packages with `pacman -Syu` to install/upgrade httpie, it's not necessary at all and I think it's most appropriate docs instructing to install/upgrade only httpie package, right?
Also, Pacman install must be run with sudo because it requires root and does not ask for authentication after called.