### PR TITLE
Disable PackIt CI on the PRs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -7,11 +7,6 @@ actions:
   # Use this when the latest spec is not up-to-date.
   # post-upstream-clone: "cp docs/packaging/linux-fedora/httpie.spec.txt httpie.spec"
 jobs:
-- job: copr_build
-  trigger: pull_request
-  metadata:
-    targets:
-    - fedora-all
 - job: propose_downstream
   trigger: release
   metadata:


### PR DESCRIPTION
We still use other functionalities (such as automatically warning downstream people when a release is ready) but the PR checks are randomly failing and the errors are very hard to decipher.