### PR TITLE
Skip on pyOpenSSL

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import os
 import socket
 
 import pytest
@@ -8,6 +7,7 @@ from .utils import ( # noqa
     HTTPBIN_WITH_CHUNKED_SUPPORT_DOMAIN,
     HTTPBIN_WITH_CHUNKED_SUPPORT,
     REMOTE_HTTPBIN_DOMAIN,
+    IS_PYOPENSSL,
     mock_env
 )
 from .utils.plugins_cli import ( # noqa
@@ -81,7 +81,7 @@ def pyopenssl_inject():
     Injects `pyOpenSSL` module to make sure `requests` will use it.
     <https://github.com/psf/requests/pull/5443#issuecomment-645740394>
     """
-    if os.getenv('HTTPIE_TEST_WITH_PYOPENSSL', '0') == '1':
+    if IS_PYOPENSSL:
         try:
             import urllib3.contrib.pyopenssl
             urllib3.contrib.pyopenssl.inject_into_urllib3()

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1,4 +1,3 @@
-import os
 import ssl
 
 import pytest
@@ -11,7 +10,7 @@ from unittest import mock
 from httpie.ssl_ import AVAILABLE_SSL_VERSION_ARG_MAPPING, DEFAULT_SSL_CIPHERS
 from httpie.status import ExitStatus
 
-from .utils import HTTP_OK, TESTS_ROOT, http
+from .utils import HTTP_OK, TESTS_ROOT, IS_PYOPENSSL, http
 
 
 try:
@@ -152,6 +151,7 @@ def test_ciphers(httpbin_secure):
     assert HTTP_OK in r
 
 
+@pytest.mark.skipif(IS_PYOPENSSL, reason='pyOpenSSL uses a different message format.')
 def test_ciphers_none_can_be_selected(httpbin_secure):
     r = http(
         httpbin_secure.url + '/get',
@@ -169,8 +169,7 @@ def test_ciphers_none_can_be_selected(httpbin_secure):
 
 
 def test_pyopenssl_presence():
-    using_pyopenssl = os.getenv('HTTPIE_TEST_WITH_PYOPENSSL', '0')
-    if using_pyopenssl == '0':
+    if not IS_PYOPENSSL:
         assert not urllib3.util.ssl_.IS_PYOPENSSL
         assert not urllib3.util.IS_PYOPENSSL
     else:

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,6 +1,7 @@
 """Utilities for HTTPie test suite."""
 import re
 import shlex
+import os
 import sys
 import time
 import json
@@ -30,6 +31,7 @@ REMOTE_HTTPBIN_DOMAIN = 'pie.dev'
 HTTPBIN_WITH_CHUNKED_SUPPORT_DOMAIN = 'pie.dev'
 HTTPBIN_WITH_CHUNKED_SUPPORT = 'http://' + HTTPBIN_WITH_CHUNKED_SUPPORT_DOMAIN
 
+IS_PYOPENSSL = os.getenv('HTTPIE_TEST_WITH_PYOPENSSL', '0') == '1'
 
 TESTS_ROOT = Path(__file__).parent.parent
 CRLF = '\r\n'


### PR DESCRIPTION
It might be one of the underlying dependencies, but when tested on both my environment and the latest CI this test constantly fails (from the time it was introduced to now). So either this test was never properly ran before or something changed in the SSL dependencies. (The failure is an error message mismatch, no behavioral change).