### PR TITLE
Deprecate --history-print.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1665,14 +1665,6 @@ $ http --all --follow pie.dev/redirect/3
 
 The intermediary requests/responses are by default formatted according to `--print, -p` (and its shortcuts described above).
 
-If you’d like to change that, use the `--history-print, -P` option.
-It takes the same arguments as `--print, -p` but applies to the intermediary requests only.
-
-```bash
-# Print the intermediary requests/responses differently than the final one:
-$ http -A digest -a foo:bar --all -p Hh -P H pie.dev/digest-auth/auth/foo/bar
-```
-
 ### Conditional body download
 
 As an optimization, the response body is downloaded from the server only if it’s part of the output.

--- a/extras/man/http.1
+++ b/extras/man/http.1
@@ -298,16 +298,6 @@ Digest auth is used \fB\,--auth\/\fR=digest), etc.
 
 
 
-.IP "\fB\,--history-print\/\fR, \fB\,-P\/\fR \fI\,WHAT\/\fR"
-
-
-The same as\fB\,--print\/\fR,\fB\,-p\/\fR but applies only to intermediary requests/responses
-(such as redirects) when their inclusion is enabled with\fB\,--all\/\fR. If this
-options is not specified, then they are formatted the same way as the final
-response.
-
-
-
 .IP "\fB\,--stream\/\fR, \fB\,-S\/\fR"
 
 

--- a/extras/man/https.1
+++ b/extras/man/https.1
@@ -298,16 +298,6 @@ Digest auth is used \fB\,--auth\/\fR=digest), etc.
 
 
 
-.IP "\fB\,--history-print\/\fR, \fB\,-P\/\fR \fI\,WHAT\/\fR"
-
-
-The same as\fB\,--print\/\fR,\fB\,-p\/\fR but applies only to intermediary requests/responses
-(such as redirects) when their inclusion is enabled with\fB\,--all\/\fR. If this
-options is not specified, then they are formatted the same way as the final
-response.
-
-
-
 .IP "\fB\,--stream\/\fR, \fB\,-S\/\fR"
 
 

--- a/httpie/cli/definition.py
+++ b/httpie/cli/definition.py
@@ -494,14 +494,7 @@ output_options.add_argument(
     '-P',
     dest='output_options_history',
     metavar='WHAT',
-    short_help='--print for intermediary requests/responses.',
-    help="""
-    The same as --print, -p but applies only to intermediary requests/responses
-    (such as redirects) when their inclusion is enabled with --all. If this
-    options is not specified, then they are formatted the same way as the final
-    response.
-
-    """,
+    help=Qualifiers.SUPPRESS,
 )
 output_options.add_argument(
     '--stream',


### PR DESCRIPTION
Soft deprecate the `--history-print` since it is not really usable.