### PR TITLE
Fix paths to run benchmarking script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ with the master branch of your repository (or a fresh checkout of HTTPie master,
 `--fresh`) and report the results back.
 
 ```bash
-$ python extras/benchmarks/run.py
+$ python extras/profiling/run.py
 ```
 
 The benchmarks can also be run on the CI. Since it is a long process, it requires manual

--- a/extras/profiling/README.md
+++ b/extras/profiling/README.md
@@ -10,7 +10,7 @@ Ensure the following requirements are satisfied:
 - Python 3.7+
 - `pyperf`
 
-Then, run the `extras/benchmarks/run.py`:
+Then, run the `extras/profiling/run.py`:
 
 ```console
 $ python extras/profiling/run.py

--- a/extras/profiling/run.py
+++ b/extras/profiling/run.py
@@ -19,19 +19,19 @@ which would include additional dependencies like pyOpenSSL.
 Examples:
 
     # Run everything as usual, and compare last commit with master
-    $ python extras/benchmarks/run.py
+    $ python extras/profiling/run.py
 
     # Include complex environments
-    $ python extras/benchmarks/run.py --complex
+    $ python extras/profiling/run.py --complex
 
     # Compare against a fresh copy
-    $ python extras/benchmarks/run.py --fresh
+    $ python extras/profiling/run.py --fresh
 
     # Compare against a custom branch of a custom repo
-    $ python extras/benchmarks/run.py --target-repo my_repo --target-branch my_branch
+    $ python extras/profiling/run.py --target-repo my_repo --target-branch my_branch
 
     # Debug changes made on this script (only run benchmarks once)
-    $ python extras/benchmarks/run.py --debug
+    $ python extras/profiling/run.py --debug
 """
 
 import dataclasses


### PR DESCRIPTION
## Purpose

**Why this PR?**
To fix incorrect paths for running benchmarking script. #1415 

## Description

**What is changed?**
- Update paths to run benchmarking script in `CONTRIBUTION.md`, `extras/profiling/README.md` & `extras/profiling/run.py`