### PR TITLE
docs: Fix a few typos

### DIFF
--- a/extras/profiling/benchmarks.py
+++ b/extras/profiling/benchmarks.py
@@ -9,7 +9,7 @@ timings.
 
 The benchmarks are run through 'pyperf', which allows to
 do get very precise results. For micro-benchmarks like startup,
-please run `pyperf system tune` to get even more acurrate results.
+please run `pyperf system tune` to get even more accurate results.
 
 Examples:
 

--- a/httpie/output/ui/rich_utils.py
+++ b/httpie/output/ui/rich_utils.py
@@ -24,7 +24,7 @@ def enable_highlighter(
     console: Console,
     highlighter: Highlighter,
 ) -> Iterator[Console]:
-    """Enable a higlighter temporarily."""
+    """Enable a highlighter temporarily."""
 
     original_highlighter = console.highlighter
     try:


### PR DESCRIPTION
There are small typos in:
- extras/profiling/benchmarks.py
- httpie/output/ui/rich_utils.py

Fixes:
- Should read `highlighter` rather than `higlighter`.
- Should read `accurate` rather than `acurrate`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md