### PR TITLE
Use `grep -E` instead of `egrep`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ default: list-tasks
 list-tasks:
 	@echo Available tasks:
 	@echo ----------------
-	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$'
+	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | grep -E -v -e '^[^[:alnum:]]' -e '^$@$$'
 	@echo
 
 


### PR DESCRIPTION
latest GNU grep emits a deprecation message when `egrep` is invoked.