### PR TITLE
Fix ci status badge error

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 [![Docs](https://img.shields.io/badge/stable%20docs-httpie.io%2Fdocs%2Fcli-brightgreen?style=flat&color=%2373DC8C&label=Docs)](https://httpie.org/docs/cli)
 [![Latest version](https://img.shields.io/pypi/v/httpie.svg?style=flat&label=Latest&color=%234B78E6&logo=&logoColor=white)](https://pypi.python.org/pypi/httpie)
-[![Build](https://img.shields.io/github/workflow/status/httpie/httpie/Build?color=%23FA9BFA&label=Build)](https://github.com/httpie/httpie/actions)
+[![Build](https://img.shields.io/github/actions/workflow/status/httpie/httpie/tests.yml?branch=master&color=%23FA9BFA&label=Build)](https://github.com/httpie/httpie/actions)
 [![Coverage](https://img.shields.io/codecov/c/github/httpie/httpie?style=flat&label=Coverage&color=%2373DC8C)](https://codecov.io/gh/httpie/httpie)
 
 </div>


### PR DESCRIPTION
Hi, this PR fixes the CI badge status error due to the recent update of shields.io. You can read the details here: https://github.com/badges/shields/issues/8671.

Also, I changed to show the status of `tests` instead of `Build`.  I couldn't find `Build` workflow so I dug into the commit history and found out that the `Build` workflow was actually removed a while ago (https://github.com/httpie/httpie/commit/4c8633c6e51f388523ab4fa649040934402a4fc9#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957f). The previous badge might have been showing a false positive status. 😅 After this fix, it will show the correct status again!

**Before**
<img width="924" alt="Screenshot 2023-01-03 at 1 44 42" src="https://user-images.githubusercontent.com/1425259/210260734-cc3599af-d485-4ff8-a1b1-ef7b250053eb.png">

**After**
<img width="947" alt="Screenshot 2023-01-03 at 2 00 34" src="https://user-images.githubusercontent.com/1425259/210260729-4308e112-48e5-4774-a7eb-8f644c59915c.png">

