### PR TITLE
Fixed installation steps for Debian & Ubuntu (#1473)

### DIFF
--- a/docs/installation/methods.yml
+++ b/docs/installation/methods.yml
@@ -39,7 +39,7 @@ tools:
       install:
         - curl -SsL https://packages.httpie.io/deb/KEY.gpg | sudo gpg --dearmor -o /usr/share/keyrings/httpie.gpg
       # - curl -SsL -o /etc/apt/sources.list.d/httpie.list https://packages.httpie.io/deb/httpie.list
-        - sudo echo "deb [arch=amd64 signed-by=/usr/share/keyrings/httpie.gpg] https://packages.httpie.io/deb ./" > /etc/sources.list.d/httpie.list
+        - sudo echo "deb [arch=amd64 signed-by=/usr/share/keyrings/httpie.gpg] https://packages.httpie.io/deb ./" > /etc/apt/sources.list.d/httpie.list
         - sudo apt update
         - sudo apt install httpie
       upgrade:

--- a/docs/installation/methods.yml
+++ b/docs/installation/methods.yml
@@ -37,13 +37,13 @@ tools:
       package: https://packages.debian.org/sid/web/httpie
     commands:
       install:
-        - curl -SsL https://packages.httpie.io/deb/KEY.gpg | apt-key add -
-        - curl -SsL -o /etc/apt/sources.list.d/httpie.list https://packages.httpie.io/deb/httpie.list
-        - apt update
-        - apt install httpie
+        - curl -SsL https://packages.httpie.io/deb/KEY.gpg | sudo gpg --dearmor -o /usr/share/keyrings/httpie.gpg
+      # - curl -SsL -o /etc/apt/sources.list.d/httpie.list https://packages.httpie.io/deb/httpie.list
+        - sudo echo "deb [arch=amd64 signed-by=/usr/share/keyrings/httpie.gpg] https://packages.httpie.io/deb ./" > /etc/sources.list.d/httpie.list
+        - sudo apt update
+        - sudo apt install httpie
       upgrade:
-        - apt update
-        - apt upgrade httpie
+        - sudo apt update && sudo apt upgrade httpie
 
   brew-mac:
     title: Homebrew


### PR DESCRIPTION
This fixes #1473 

If you use `deb [arch=amd64 signed-by=/usr/share/keyrings/httpie.gpg] https://packages.httpie.io/deb ./ ` as a replacement for your [httpie.list](https://packages.httpie.io/deb/httpie.list) content, the commented out command can replace the new one again.