### PR TITLE
Style guide: use isinstance()

### DIFF
--- a/httpie/core.py
+++ b/httpie/core.py
@@ -293,6 +293,6 @@ def decode_raw_args(
     """
     return [
         arg.decode(stdin_encoding)
-        if type(arg) is bytes else arg
+        if isinstance(arg, bytes) else arg
         for arg in args
     ]

--- a/httpie/sessions.py
+++ b/httpie/sessions.py
@@ -204,7 +204,7 @@ class Session(BaseConfigDict):
                 continue  # Ignore explicitly unset headers
 
             original_value = value
-            if type(value) is not str:
+            if not isinstance(value, str):
                 value = value.decode()
 
             if name.lower() == 'user-agent' and value.startswith('HTTPie/'):


### PR DESCRIPTION
Used the `isinstance()` function to avoid comparing two datatypes directly. 