### PR TITLE
Fix `urllib3.util.ssl_.DEFAULT_CIPHERS` import

### DIFF
--- a/httpie/cli/definition.py
+++ b/httpie/cli/definition.py
@@ -831,8 +831,8 @@ ssl.add_argument(
     short_help='A string in the OpenSSL cipher list format.',
     help=f"""
 
-    A string in the OpenSSL cipher list format. By default, the following
-    is used:
+    A string in the OpenSSL cipher list format. By default, the available
+    system ciphers will be used, which are:
 
     {DEFAULT_SSL_CIPHERS}
 

--- a/httpie/ssl_.py
+++ b/httpie/ssl_.py
@@ -3,13 +3,9 @@ from typing import NamedTuple, Optional
 
 from httpie.adapters import HTTPAdapter
 # noinspection PyPackageRequirements
-from urllib3.util.ssl_ import (
-    DEFAULT_CIPHERS, create_urllib3_context,
-    resolve_ssl_version,
-)
+from urllib3.util.ssl_ import create_urllib3_context, resolve_ssl_version
 
 
-DEFAULT_SSL_CIPHERS = DEFAULT_CIPHERS
 SSL_VERSION_ARG_MAPPING = {
     'ssl2.3': 'PROTOCOL_SSLv23',
     'ssl3': 'PROTOCOL_SSLv3',
@@ -94,3 +90,12 @@ def _is_key_file_encrypted(key_file):
                 return True
 
     return False
+
+
+try:
+    from urllib3.util.ssl_ import DEFAULT_CIPHERS
+except ImportError:
+    _context = HTTPieHTTPSAdapter._create_ssl_context(verify=False)
+    DEFAULT_CIPHERS = ":".join([cipher["name"] for cipher in _context.get_ciphers()])
+
+DEFAULT_SSL_CIPHERS = DEFAULT_CIPHERS


### PR DESCRIPTION
## Description

[urllib3 2.0 was released on 2023-04-26](https://urllib3.readthedocs.io/en/stable/changelog.html). One of the changes was the removal of `urllib3.util.ssl_.DEFAULT_CIPHERS`. urllib3 now detects and uses the default ciphers configured by the system (https://github.com/urllib3/urllib3/issues/2168, https://github.com/urllib3/urllib3/pull/2705).

[Requests currently allows](https://github.com/psf/requests/blob/2ad18e0e10e7d7ecd5384c378f25ec8821a10a29/setup.py#L61-L66) `urllib3>=1.21.1,<3`. HTTPie has an indirect dependency on urllib3 (through Requests), and currently imports the `DEFAULT_CIPHERS` constant and uses it to populate CLI help text for the `--ciphers` flag.

https://github.com/httpie/httpie/blob/47e9b99ba19b2a9d3e0098726fff4469b9dd6bb0/httpie/ssl_.py#L6-L12

https://github.com/httpie/httpie/blob/47e9b99ba19b2a9d3e0098726fff4469b9dd6bb0/httpie/cli/definition.py#L830-L837

This means that users who install HTTPie with `urllib3>=2` will see an `ImportError` (httpie/httpie#1499).

## Changes

This PR will update HTTPie to catch the `ImportError` and assemble a list of default ciphers in the OpenSSL cipher list format.

Please note that GitHub Actions workflow runs appear to be failing because of pre-existing errors, not necessarily because of the changes in this PR.

Longer-term, it would be prudent to avoid importing from private modules in indirect dependencies.

If it is going to take some time to support urllib3 2.0, it could also be helpful to declare a direct dependency on `urllib3>1,<2` in `setup.py`.

## Related

- Closes httpie/httpie#1499
- [urllib3 changelog](https://urllib3.readthedocs.io/en/stable/changelog.html)
- [urllib3 2.0 migration guide](https://urllib3.readthedocs.io/en/stable/v2-migration-guide.html)
- https://github.com/httpie/httpie/issues/870
- https://github.com/urllib3/urllib3/issues/2168
- https://github.com/urllib3/urllib3/pull/2705
- https://github.com/boto/botocore/issues/2921
- https://github.com/boto/botocore/pull/2924
