### PR TITLE
README.md: fix the file based separators internal link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1180,7 +1180,7 @@ All of these can be overwritten or unset (see below).
 
 ### Reading headers from a file
 
-You can read headers from a file by using the `:@` operator. This would also effectively strip the newlines from the end. See [#file-based-separators] for more examples.
+You can read headers from a file by using the `:@` operator. This would also effectively strip the newlines from the end. See [file based separators](#file-based-separators) for more examples.
 
 ```bash
 $ http pie.dev/headers X-Data:@files/text.txt


### PR DESCRIPTION
The link to "file based separators" in the "Reading headers from a file" section when rendered to HTML does not work. The link is now fixed by providing a URL and link text, based on the existing link in the "Querystring parameters" section.


## The problem
<img width="786" alt="Screenshot 2023-05-24 at 9 55 08 AM" src="https://github.com/rudolfolah/httpie/assets/89982117/9bb69849-ac38-4257-b4f0-ca468db4f979">

## Example of a working link
<img width="810" alt="Screenshot 2023-05-24 at 9 54 00 AM" src="https://github.com/rudolfolah/httpie/assets/89982117/dc565d7e-69b5-4b0a-9c95-f7f4467eceda">
