### PR TITLE
Fix average download speed (httpie#1516)

### DIFF
--- a/httpie/output/ui/rich_progress.py
+++ b/httpie/output/ui/rich_progress.py
@@ -105,7 +105,7 @@ class ProgressDisplay(BaseDisplay):
             TimeRemainingColumn,
             TransferSpeedColumn,
         )
-
+        self.resumed_at = at
         assert total is not None
         self.console.print(f'[progress.description]{description}')
         self.progress_bar = Progress(
@@ -136,6 +136,6 @@ class ProgressDisplay(BaseDisplay):
             [task] = self.progress_bar.tasks
             self._print_summary(
                 is_finished=task.finished,
-                observed_steps=task.completed,
+                observed_steps=task.completed - self.resumed_at,
                 time_spent=time_spent,
             )


### PR DESCRIPTION
## Problem
When `DownloadStatus` is finished, it calls `ProgressDisplay.stop()`, where `ProgressDisplay._print_summary()` method is called.

Here in `_print_summary()` we incorrectly assume that `task.completed` means observed steps, but in fact it equals to `task.total` at finish, which leads to this issue - no matter where we resume, we always get `task.total` steps.

## Solution
- Extend the `ProgressDisplay` class by adding a `resumed_at` attribute to keep track of the progress that has already been done.
- Change the `ProgressDisplay.stop()` method to pass `task.completed - self.resumed_at` instead of `task.completed`

## Related
Solves the issue #1516